### PR TITLE
Add Travis CI builds for Linux and macOS.

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+  brew update
+  brew install findutils
+  brew install qt5
+  brew link qt5 --force
+  brew cask reinstall java
+  brew outdated gradle || brew upgrade gradle
+  brew unlink python # fixes 'run_one_line' is not defined error in backtrace
+fi

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+BOOT_JDK10_VER="42"
+BOOT_JDK10="jdk-10-ea+42"
+
+echo "which java: $(which java)"
+ulimit -c unlimited -S
+
+gradle build -x :web:test --no-daemon --stacktrace --info
+
+# Print core dumps when JVM crashes.
+RESULT=$?
+
+if [[ ${RESULT} -ne 0 ]]; then
+  if [ ! -z ${PRINT_CRASH_LOGS+x} ]; then
+    if [[ "${TRAVIS_OS_NAME}" == osx ]]; then FIND="gfind"; else FIND="find"; fi
+    ${FIND} . -name "hs_err_pid*.log" -type f -printf '\n====== JVM CRASH LOG ======\n%p\n' -exec cat {} \;
+
+    CORES=''
+    if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+      CORES="$(find /cores -type f -regex '*core.[0-9]{4}' -print)"
+    else
+      CORES="$(find . -type f -regex '*core.[0-9]{6}' -print)"
+    fi
+
+    if [ -n "${CORES}" ]; then
+      for core in ${CORES}; do
+        printf '\n\n======= Core file %s =======\n' "$core"
+        if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+          lldb -Q -o "bt all" -f "$(which java)" -c "${core}"
+        else
+          gdb -n -batch -ex "thread apply all bt" -ex "set pagination 0" "$(which java)" -c "${core}"
+        fi
+      done
+    fi
+  fi
+  exit ${RESULT}
+fi
+
+# Download JDK 10 to use for boot JDK for building JDK 11.
+cd "$TRAVIS_BUILD_DIR"
+if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+  BOOT_JDK_MAC="${BOOT_JDK10}_osx-x64_bin.dmg"
+  wget https://download.java.net/java/jdk10/archive/"$BOOT_JDK10_VER"/BCL/"$BOOT_JDK_MAC"
+  hdiutil attach "$BOOT_JDK_MAC" -mountpoint ~/_mount
+  # The following dance is done to avoid calling "installer" which requires root.
+  pkgutil --expand ~/_mount/JDK\ 10.pkg ~/jdk-10-compressed
+  mkdir -p ~/jdk-10
+  tar xvf ~/jdk-10-compressed/jdk10.pkg/Payload -C ~/jdk-10 --strip-components 3 # Strip Contents/Home/
+else
+  BOOT_JDK_LINUX="${BOOT_JDK10}_linux-x64_bin.tar.gz"
+  wget https://download.java.net/java/jdk10/archive/"$BOOT_JDK10_VER"/BCL/"$BOOT_JDK_LINUX"
+  tar xvf "$BOOT_JDK_LINUX"
+fi
+
+
+# Now that OpenJFX has been built, we will build OpenJDK and configure
+# it to use our newly built OpenJFX
+git clone --depth=1 -b dev https://github.com/adoptopenjdk/openjdk-jdk10.git jdk
+cd jdk/
+chmod +x configure
+unset _JAVA_OPTIONS
+if [[ "${TRAVIS_OS_NAME}" == osx ]]; then BOOT_JDK="~/jdk-10"; else BOOT_JDK="$TRAVIS_BUILD_DIR/jdk-10"; fi
+bash configure --with-import-modules="$TRAVIS_BUILD_DIR"/build/modular-sdk --with-boot-jdk="$BOOT_JDK"
+
+# Actually building the JDK exceeds the time limit (and maybe even the memory limit)
+# of Travis, for the free/open-source tier. Keep this in case we get the proper infrastructure
+# in place to build the JDK with Travis.
+if false ; then
+  make images
+  ./build/*/images/jdk/bin/java -version
+  make run-test-tier1
+fi
+
+# vim :set ts=2 sw=2 sts=2 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,81 @@
+language: java
+sudo: false
+
+addons:
+  apt:
+    packages: &global_deps
+      - ksh
+      - bison
+      - flex
+      - gperf
+      - libasound2-dev
+      - libgl1-mesa-dev
+      - libgstreamer0.10-dev
+      - libgstreamer-plugins-base0.10-dev
+      - libjpeg-dev
+      - libpng-dev
+      - libx11-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - libxt-dev
+      - libxxf86vm-dev
+      - pkg-config
+      - libavcodec-dev
+      - mercurial
+      - libgtk2.0-dev
+      - libgtk-3-dev
+      - libxtst-dev
+      - libudev-dev
+      - libavformat-dev
+      - cmake
+      - ruby
+      - gdb
+      - libcups2-dev
+
+# For webkit: t5-qmake qtbase5-dev qtdeclarative5-dev libqt5webkit5-dev ?
+# Won't be able to build webkit in the time alloted by Travis
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk9
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
+            - *global_deps
+    - os: osx
+      osx_image: xcode9
+      env:
+        - PRINT_CRASH_LOGS="true"
+
+before_script:
+  - wget https://services.gradle.org/distributions/gradle-4.3-bin.zip
+  - unzip gradle-4.3-bin.zip
+  - export GRADLE_HOME=$PWD/gradle-4.3
+  - export PATH=$GRADLE_HOME/bin:$PATH
+  - echo $JAVA_OPTS
+  - echo $GRADLE_OPTS
+  # run on xvfb screen (for linux).
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start; fi
+
+before_install: .ci/before_install.sh
+
+# skip install stage.
+install: true
+
+script: .ci/script.sh
+
+notifications:
+  email: false
+


### PR DESCRIPTION
This PR adds support for building OpenJFX using [Travis CI](https://travis-ci.org/).

In order to make this work, the project will have to be (freely) registered with Travis. I personally login with my Github credentials to link a project when I use Travis.

Here is an example Travis build with the same configuration (just on my temporary openjfx repo):

https://travis-ci.org/brcolow/openjfx/builds/341230348

Note that the builds that are listed as "untagged-xxxxx" would not appear on this repo, that was just for testing purposes to automatically upload failed test screenshots.