### PR TITLE
Set the locale of the javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4081,6 +4081,7 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     options.windowTitle("${javadocTitle}")
     options.header("${javadocHeader}")
     options.bottom("${javadocBottom}")
+    options.locale("en");
     if (BUILD_CLOSED) {
         options.linksOffline(JDK_DOCS, JDK_DOCS_CLOSED);
     } else {


### PR DESCRIPTION
Setting the locale to a fixed value when generating the javadoc ensures the output of the build doesn't depend on developer specific settings. This improves the [reproducibility](https://reproducible-builds.org) of the build.