### PR TITLE
Fix PosixPlatform.cpp compilation with GCC 6

### DIFF
--- a/modules/jdk.packager/src/main/native/library/common/PosixPlatform.cpp
+++ b/modules/jdk.packager/src/main/native/library/common/PosixPlatform.cpp
@@ -53,6 +53,7 @@
 #include <algorithm>
 #include <dlfcn.h>
 #include <signal.h>
+#include <sys/wait.h>
 
 
 PosixPlatform::PosixPlatform(void) {
@@ -380,7 +381,7 @@ bool PosixProcess::Wait() {
     pid_t wpid = 0;
 
 #ifdef LINUX
-    wait();
+    wait(&status);
 #endif
 #ifdef MAC
     wpid = wait(&status);


### PR DESCRIPTION
PosixPlatform.cpp fails to compile with GCC 6:

    /<<PKGBUILDDIR>>/modules/fxpackager/src/main/native/library/common/PosixPlatform.cpp:235:10: error: 'wait' was not declared in this scope
         wait();
              ^

This issue has been fixed in Debian.