### PR TITLE
Qt-dev tools are no longer needed by OpenJFX

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew update
   brew install findutils
-  brew install qt5
-  brew link qt5 --force
   brew cask reinstall java
   brew outdated gradle || brew upgrade gradle
   brew unlink python # fixes 'run_one_line' is not defined error in backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
       - gdb
       - libcups2-dev
 
-# For webkit: t5-qmake qtbase5-dev qtdeclarative5-dev libqt5webkit5-dev ?
 # Won't be able to build webkit in the time alloted by Travis
 
 before_cache:


### PR DESCRIPTION
This changeset is related to #45. Qt is no longer needed to build OpenJFX, Once it was required to build JFX along with WebKit.(i.e. -PCOMPILE_WEBKIT=true), but now OpenJFX WebKit uses cmake as a meta build system.