### PR TITLE
Add script used by jenkins job to sync with openjfx mercurial repository

### DIFF
--- a/.github/sync_upstream.sh
+++ b/.github/sync_upstream.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "Enter hg"
+cd hg
+
+pushd openjfx/jfx-dev/rt/root
+echo "Update openjfx/jfx-dev/rt -> (root)"
+git hg fetch "http://hg.openjdk.java.net/openjfx/jfx-dev/rt"
+git hg pull "http://hg.openjdk.java.net/openjfx/jfx-dev/rt"
+popd
+
+echo "Exit hg"
+echo "Enter combined"
+
+cd ../combined
+
+echo "Check out master"
+git checkout master
+
+echo "Fetch (root)"
+git fetch "imports/openjfx/jfx-dev/rt/root"
+
+echo "Merge (root)"
+git merge "imports/openjfx/jfx-dev/rt/root/master" -m "Merge from (root)" --no-ff
+
+echo "Push master (github)"
+git push github master --tags
+
+echo "Check out develop"
+git checkout develop
+
+echo "Pull (github)"
+git pull github develop
+
+echo "Merge (master)"
+git merge master -m "Merge from master" --no-ff
+
+echo "Push develop (github)"
+git push github develop --tags


### PR DESCRIPTION
Add the script that is used by the jenkins job to synchronise the OpenJFX mercurial repository with the fork on github. This allows others to make changes to the synchronisation process.