### PR TITLE
JDK-8200446: Update minimum boot JDK to 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1684,7 +1684,7 @@ allprojects {
     // All of our projects are java projects
 
     apply plugin: "java"
-    sourceCompatibility = 1.9
+    sourceCompatibility = 10
 
     // By default all of our projects require junit for testing so we can just
     // setup this dependency here.

--- a/build.properties
+++ b/build.properties
@@ -72,5 +72,5 @@ javadoc.header=JavaFX&nbsp;11
 #
 ##############################################################################
 
-jfx.build.jdk.version.min=9
-jfx.build.jdk.buildnum.min=181
+jfx.build.jdk.version.min=10
+jfx.build.jdk.buildnum.min=46


### PR DESCRIPTION
Fixes [JDK-8200446](https://bugs.openjdk.java.net/browse/JDK-8200446)

I'm doing it here first to make sure that the CI system for this sandbox is already using JDK 10 and thus won't be affected.