### PR TITLE
IntelliJ IDEA should use GIT instead of Mercurial

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="hg4idea" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
Until .idea directory is added to the ignore list, this helps IntellIJ IDEA to recognise the project as GIT based.

**NOTE:** This should not be pushed upstream to hg.openjdk.java.net/openjfx