### PR TITLE
Generate PDB (debugging files) and upload them via Appveyor, use them to get native backtrace.

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -16,7 +16,6 @@ if [[ ${RESULT} -ne 0 ]]; then
   if [ ! -z ${PRINT_CRASH_LOGS+x} ]; then
     if [[ "${TRAVIS_OS_NAME}" == osx ]]; then FIND="gfind"; else FIND="find"; fi
     ${FIND} . -name "hs_err_pid*.log" -type f -printf '\n====== JVM CRASH LOG ======\n%p\n' -exec cat {} \;
-
     CORES=''
     if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
       CORES="$(find /cores -type f -regex '*core.[0-9]{4}' -print)"
@@ -26,11 +25,11 @@ if [[ ${RESULT} -ne 0 ]]; then
 
     if [ -n "${CORES}" ]; then
       for core in ${CORES}; do
-        printf '\n\n======= Core file %s =======\n' "$core"
+        printf '\n\n======= NATIVE BACK TRACE (%s) =======\n' "$core"
         if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-          lldb -Q -o "bt all" -f "$(which java)" -c "${core}"
+          lldb --batch -o "thread backtrace all" -f "$(which java)" -c "${core}"
         else
-          gdb -n -batch -ex "thread apply all bt" -ex "set pagination 0" "$(which java)" -c "${core}"
+          gdb -n -batch -ex "thread apply all bt" "$(which java)" -c "${core}"
         fi
       done
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,7 @@ shallow_clone: true
 
 build_script:
   - ps: |
-      choco install jdk10 -params 'installdir=c:\\jdk10'
-      choco install gradle --version 4.3.0
+      choco install jdk10 --force --cache 'C:\ProgramData\chocolatey\cache' -params 'installdir=c:\\jdk10'
       $msvcToolsVer = Get-Content "$env:VCINSTALLDIR\Microsoft.VCToolsVersion.default.txt"
       if ([string]::IsNullOrWhitespace($msvcToolsVer)) {
         # The MSVC tools version file can have txt *or* props extension.
@@ -23,17 +22,41 @@ build_script:
       $env:VSVARS32FILE = "$env:VCINSTALLDIR\vcvars32.bat"
       refreshenv
       # Must invoke gradle with cmd.exe so stderr output doesn't fail the build:
-  - cmd: gradlew test -PCOMPILE_WEBKIT=false --stacktrace -x :web:test --info --no-daemon
+  - cmd: gradlew build -PCOMPILE_WEBKIT=false -PCONF=DebugNative --stacktrace -x :web:test --info --no-daemon
+
 on_finish:
   - ps: |
+        $dbgDir = ".\javafx-debug-symbols\"
+        $dbgArchive = "javafx-debug-symbols.zip"
+        if ((Get-ChildItem -Include @("*.pdb","*.map") -Recurse | Where { -not $_.PSIsContainer}).Count -gt 0) {
+          # The build generated at least one map or pdb file, so bundle them and upload to Appveyor.
+          Get-ChildItem -Include @("*.pdb","*.map") -Recurse | Copy-Item -Destination (New-Item -Type directory -Force $dbgDir) -Force
+          Compress-Archive -Path $($dbgDir + '*') -DestinationPath $dbgArchive -CompressionLevel Optimal
+          Push-AppveyorArtifact $dbgArchive -Verbose
+        }
+
         $crashes = Get-ChildItem -Include hs_err_pid*.log -Recurse
-        Write-Output $crashes
-        $javaExe = $env.JAVA_HOME + '\bin\java.exe'
-        # This could be made much more useful if we had win32 debugging symbols for the JDK.
+        $javaExe = $env:JAVA_HOME + '\bin'
         ForEach ($crash in $crashes) {
+          $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\"
+          $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\"
+          $env:Path += ";C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x64\"
+          $env:Path += ";C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\"
+          Write-Host "Printing crash dump (${crash}):"
           Get-Content $crash
-          $crashDump = $crash.Name + '.mdmp'
-          Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe" -ArgumentList "-v -z $crashDump -c '!sym noisy;~*;kb;q' -i $javaExe"
+          $crashDump = $crash.DirectoryName + '\' + $crash.Basename + '.mdmp'
+          Write-Host "\n\n--- NATIVE BACK TRACE ---"
+          # https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/cdb-command-line-options
+          # !sym noisy = Activates noisy symbol loading.
+          # ~* = Thread status for all threads in the process.
+          # .kframes 100 = Set stack length to 100 frames.
+          # kP = Display stack backtrace with the full parameters for each function that is called in the stack trace.
+          # .ecxr = Display exception context record.
+          # dpp = Display referenced memory (32-bit or 64-bit depending on architecture) in DWORD or QWORD.
+          # r. = Displays the registers used in the current instruction.
+          # q = Quit.
+          cdb -v -z $crashDump -c '!sym noisy;~*;kP;dpp;r.;q' -i $javaExe -lines -y "srv*C:\MSSymbols*http://msdl.microsoft.com/download/symbols;$($env:APPVEYOR_BUILD_FOLDER)\javafx-debug-symbols\"
+          Write-Host "\n\n--- END NATIVE BACK TRACE ---"
         }
 
         # This technically works but is really inefficient as it requires an HTTP request for every
@@ -43,7 +66,7 @@ on_finish:
         # https://www.appveyor.com/docs/build-worker-api/#rest-3
         # In order to do this we will need to iterate over all the XML files and convert them into
         # a big JSON array.
-        Write-Output -Message 'Uploading test results to AppVeyor…' -Verbose
+        Write-Host 'Uploading test results to AppVeyor…'
         $wc = New-Object 'System.Net.WebClient'
         $modules = @("javafx.base", "javafx.graphics", "javafx.controls", "javafx.fxml")
         $ErrorActionPreference = "SilentlyContinue"
@@ -59,15 +82,17 @@ on_finish:
           }
         }
 
-  - cmd: |
-        REM Currently building OpenJDK exceeds Appveyor's time limits. Keep this around
-        REM in case we ever get the proper infrastructure.
-        REM hg clone http://hg.openjdk.java.net/jdk/jdk
-        REM cd jdk/
-        REM C:\cygwin\bin\bash "PATH=/bin:/cygdrive/c/Windows/System32:/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build && ./configure --with-import-modules=/cygdrive/c/projects/openjfx/build/modular-sdk --with-boot-jdk=/cygdrive/c/jdk-10"
+on_success:
+  - ps: |
+        $modules = "javafx-modules.zip"
+        Compress-Archive -Path ".\build\modular-sdk" -DestinationPath $modules -CompressionLevel Optimal
+        Push-AppveyorArtifact $modules -Verbose
 
 cache:
   - C:\Users\appveyor\.gradle\caches
+  - C:\Users\appveyor\.gradle\wrapper -> .gradle-wrapper\gradle-wrapper.properties
   - '%JAVA_HOME% -> appveyor.yml'
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\ProgramData\chocolatey\cache -> appveyor.yml
+  - C:\MSSymbols -> appveyor.yml


### PR DESCRIPTION
The intent of this pull-request is to generate and then upload the debugging symbols (`*.pdb` and `*.map` files) generated during the Windows Appveyor build of OpenJFX. The files will be uploaded using [Appveyor's artifacts feature](https://www.appveyor.com/docs/packaging-artifacts/). Such debugging files are generated by switching the gradle `CONF` property from the default `Release` to `DebugNative`. These [`*.pdb` files](https://docs.microsoft.com/en-us/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger) can be used to get symbol information when debugging a JVM crash on Windows. Going forward this could be useful whenever we touch native Windows code which will definitely need to be done in order to keep JavaFX modern.

This PR is a follow-up to the comment I put in `.appveyor.yml` about making the `cdb.exe` back-traces *more* useful. In fact, they were not useful at *all* because what was there didn't work. Now that I am working on https://github.com/javafxports/openjdk-jfx/issues/66 this gave me the motivation to try and actually implement this functionality.

You can see the uploaded artifact by clicking on the [Appveyor "Artifacts" tab](https://ci.appveyor.com/project/javafxports-github-bot/openjdk-jfx/build/develop%20223/artifacts) on the Appveyor build page of this PR. I also took this opportunity to upload the JavaFX modules which will be especially useful when it will be possible to "overlay" those modules on top of the JDK.

At least one thing that is still WIP is figuring out how we can get PDB files for the JDK itself for whatever Java version that Appveyor build is using. I temporarily and for testing purposes only used the PDB files published by https://github.com/ojdkbuild/ojdkbuild.

Update: It appears that the builds offered by [AdoptOpenJDK](https://adoptopenjdk.net/) come with PDB files. I will most likely use their API to fetch the Java symbols.

Update 2: I think it makes sense to do this is a future PR as this PR addresses the most common use-case where the crash occurs in the JavaFX native windows code.