### PR TITLE
add timeout to antlr processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1752,6 +1752,8 @@ project(":graphics") {
         main = "org.antlr.Tool"
 
         args = [
+            "-Xconversiontimeout",
+            "30000",
             "-o",
             "$buildDir/gensrc/antlr",
             "com/sun/scenario/effect/compiler/JSL.g" ]


### PR DESCRIPTION
This fixes issue #25 and obsoletes PR #10 which had a similar change in buildSrc/linux.gradle. 
Since that code is not used anymore, this PR has the same fix in build.gradle