### PR TITLE
Fix JDK-8202743: Dashed Stroke randomly painted incorrectly, may freeze application

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DDasher.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DDasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,17 +107,19 @@ public final class DDasher implements DPathConsumer2D, MarlinConst {
      * @param recycleDashes true to indicate to recycle the given dash array
      * @return this instance
      */
-    public DDasher init(final DPathConsumer2D out, double[] dash, int dashLen,
-                double phase, boolean recycleDashes)
+    public DDasher init(final DPathConsumer2D out, final double[] dash, final int dashLen,
+                        double phase, final boolean recycleDashes)
     {
         this.out = out;
 
         // Normalize so 0 <= phase < dash[0]
         int sidx = 0;
         dashOn = true;
+
+        // note: BasicStroke constructor checks dash elements and sum > 0
         double sum = 0.0d;
-        for (double d : dash) {
-            sum += d;
+        for (int i = 0; i < dashLen; i++) {
+            sum += dash[i];
         }
         double cycles = phase / sum;
         if (phase < 0.0d) {
@@ -125,13 +127,13 @@ public final class DDasher implements DPathConsumer2D, MarlinConst {
                 phase = 0.0d;
             } else {
                 int fullcycles = FloatMath.floor_int(-cycles);
-                if ((fullcycles & dash.length & 1) != 0) {
+                if ((fullcycles & dashLen & 1) != 0) {
                     dashOn = !dashOn;
                 }
                 phase += fullcycles * sum;
                 while (phase < 0.0d) {
                     if (--sidx < 0) {
-                        sidx = dash.length - 1;
+                        sidx = dashLen - 1;
                     }
                     phase += dash[sidx];
                     dashOn = !dashOn;
@@ -142,14 +144,14 @@ public final class DDasher implements DPathConsumer2D, MarlinConst {
                 phase = 0.0d;
             } else {
                 int fullcycles = FloatMath.floor_int(cycles);
-                if ((fullcycles & dash.length & 1) != 0) {
+                if ((fullcycles & dashLen & 1) != 0) {
                     dashOn = !dashOn;
                 }
                 phase -= fullcycles * sum;
                 double d;
                 while (phase >= (d = dash[sidx])) {
                     phase -= d;
-                    sidx = (sidx + 1) % dash.length;
+                    sidx = (sidx + 1) % dashLen;
                     dashOn = !dashOn;
                 }
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,17 +108,19 @@ public final class Dasher implements PathConsumer2D, MarlinConst {
      * @param recycleDashes true to indicate to recycle the given dash array
      * @return this instance
      */
-    public Dasher init(final PathConsumer2D out, float[] dash, int dashLen,
-                float phase, boolean recycleDashes)
+    public Dasher init(final PathConsumer2D out, final float[] dash, final int dashLen,
+                       float phase, final boolean recycleDashes)
     {
         this.out = out;
 
         // Normalize so 0 <= phase < dash[0]
         int sidx = 0;
         dashOn = true;
+
+        // note: BasicStroke constructor checks dash elements and sum > 0
         float sum = 0.0f;
-        for (float d : dash) {
-            sum += d;
+        for (int i = 0; i < dashLen; i++) {
+            sum += dash[i];
         }
         float cycles = phase / sum;
         if (phase < 0.0f) {
@@ -126,13 +128,13 @@ public final class Dasher implements PathConsumer2D, MarlinConst {
                 phase = 0.0f;
             } else {
                 int fullcycles = FloatMath.floor_int(-cycles);
-                if ((fullcycles & dash.length & 1) != 0) {
+                if ((fullcycles & dashLen & 1) != 0) {
                     dashOn = !dashOn;
                 }
                 phase += fullcycles * sum;
                 while (phase < 0.0f) {
                     if (--sidx < 0) {
-                        sidx = dash.length - 1;
+                        sidx = dashLen - 1;
                     }
                     phase += dash[sidx];
                     dashOn = !dashOn;
@@ -143,14 +145,14 @@ public final class Dasher implements PathConsumer2D, MarlinConst {
                 phase = 0.0f;
             } else {
                 int fullcycles = FloatMath.floor_int(cycles);
-                if ((fullcycles & dash.length & 1) != 0) {
+                if ((fullcycles & dashLen & 1) != 0) {
                     dashOn = !dashOn;
                 }
                 phase -= fullcycles * sum;
                 float d;
                 while (phase >= (d = dash[sidx])) {
                     phase -= d;
-                    sidx = (sidx + 1) % dash.length;
+                    sidx = (sidx + 1) % dashLen;
                     dashOn = !dashOn;
                 }
             }

--- a/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
@@ -95,6 +95,7 @@ public class DashedRectTest {
         public void start(Stage primaryStage) throws Exception {
             this.stage = primaryStage;
 
+            stage.setScene(new Scene(new Group()));
             stage.setTitle("DashedRectTest");
             stage.show();
 
@@ -130,8 +131,6 @@ public class DashedRectTest {
     public void TestDashedPath() throws InterruptedException {
 
         final int size = MAX * 2;
-
-        final WritableImage img = new WritableImage(size, size);
 
         Util.runAndWait(() -> {
 
@@ -177,14 +176,14 @@ public class DashedRectTest {
             final SnapshotParameters sp = new SnapshotParameters();
             sp.setViewport(new Rectangle2D(0, 0, size, size));
 
-            scene.getRoot().snapshot(sp, img);
+            final WritableImage img = scene.getRoot().snapshot(sp, new WritableImage(size, size));
+
+            // Check image on few pixels:
+            final PixelReader pr = img.getPixelReader();
+
+            // 10, 5 = blue
+            checkPixel(pr, 10, 5, BLUE_PIXEL);
         });
-
-        // Check image on few pixels:
-        final PixelReader pr = img.getPixelReader();
-
-        // 10, 5 = blue
-        checkPixel(pr, 10, 5, BLUE_PIXEL);
     }
 
     private static void checkPixel(final PixelReader pr,

--- a/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.com.sun.marlin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.SnapshotParameters;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.WritableImage;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.ClosePath;
+import javafx.scene.shape.HLineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
+import javafx.scene.shape.VLineTo;
+import javafx.stage.Stage;
+
+import junit.framework.AssertionFailedError;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static test.util.Util.TIMEOUT;
+
+/**
+ * Simple Dashed Rect rendering test
+ *
+ * @test
+ * @summary verify that dashed rectangle is properly rasterized
+ * @bug 8202743
+ */
+public class DashedRectTest {
+
+    static final int BLUE_PIXEL = 0xff0000ff;
+
+    static final File OUTPUT_DIR = new File(".");
+
+    final static double DASH_LEN = 3.0;
+    final static double DASH_PH = 5000.0;
+
+    final static int MAX = 100;
+
+    // Used to launch the application before running any test
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    // Singleton Application instance
+    static MyApp myApp;
+
+    // Application class. An instance is created and initialized before running
+    // the first test, and it lives through the execution of all tests.
+    public static class MyApp extends Application {
+
+        Stage stage = null;
+
+        public MyApp() {
+            super();
+        }
+
+        @Override
+        public void init() {
+            DashedRectTest.myApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            this.stage = primaryStage;
+
+            // Corrupt Marlin Dasher.dash cached array:
+            final Path path1 = new Path();
+            path1.getElements().addAll(
+                    new MoveTo(20, 20),
+                    new HLineTo(70),
+                    new VLineTo(70),
+                    new HLineTo(20),
+                    new ClosePath()
+            );
+            path1.setStroke(Color.RED);
+            path1.setFill(null);
+            path1.setStrokeWidth(2);
+            path1.setStrokeDashOffset(DASH_PH);
+
+            final ObservableList<Double> pDashes = path1.getStrokeDashArray();
+            pDashes.clear();
+            for (int i = 0; i < 100; i++) {
+                pDashes.add(19.333);
+            }
+
+            // Create 2nd path shape
+            final Path path2 = new Path();
+            path2.getElements().addAll(
+                    new MoveTo(5, 5),
+                    new HLineTo(MAX),
+                    new VLineTo(MAX),
+                    new HLineTo(5),
+                    new ClosePath()
+            );
+            path2.setFill(null);
+            path2.setStroke(Color.BLUE);
+            path2.setStrokeWidth(2);
+            path2.setStrokeDashOffset(DASH_PH);
+            path2.getStrokeDashArray().setAll(DASH_LEN);
+
+            Scene scene = new Scene(new Group(path1, path2));
+            stage.setScene(scene);
+            stage.setTitle("DashedRectTest");
+            stage.show();
+
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        // Start the Application
+        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
+
+        try {
+            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
+                throw new AssertionFailedError("Timeout waiting for Application to launch");
+            }
+
+        } catch (InterruptedException ex) {
+            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
+            err.initCause(ex);
+            throw err;
+        }
+
+        assertEquals(0, launchLatch.getCount());
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.exit();
+    }
+
+    @Test(timeout = 10000)
+    public void TestDashedPath() throws InterruptedException, IOException {
+
+        final int size = MAX * 2;
+
+        final WritableImage img = new WritableImage(size, size);
+
+        done = false;
+        Platform.runLater(() -> {
+            final SnapshotParameters sp = new SnapshotParameters();
+            sp.setViewport(new Rectangle2D(0, 0, size, size));
+
+            myApp.stage.getScene().getRoot().snapshot(sp, img);
+
+            signalDone();
+        });
+
+        waitDone();
+
+        // Check image on few pixels:
+        final PixelReader pr = img.getPixelReader();
+
+        // 10, 5 = blue
+        checkPixel(pr, 10, 5, BLUE_PIXEL);
+    }
+
+    boolean done;
+
+    synchronized void signalDone() {
+        done = true;
+        notifyAll();
+    }
+
+    synchronized void waitDone() throws InterruptedException {
+        while (!done) {
+            wait();
+        }
+    }
+
+    private static void checkPixel(final PixelReader pr,
+                                   final int x, final int y,
+                                   final int expected) {
+
+        final int rgb = pr.getArgb(x, y);
+        if (rgb != expected) {
+            throw new IllegalStateException("bad pixel at (" + x + ", " + y
+                    + ") = " + rgb + " expected: " + expected);
+        }
+    }
+}


### PR DESCRIPTION
This PR corresponds to the jfx backport of the JDK-8202580 bug fix:
https://bugs.openjdk.java.net/browse/JDK-8202580

Notes: 
- (D)Dasher changes corresponds to MarlinFX 0.8.2 (upgrade to 0.9.2 later) 
- test adapted to javafx API using scene.snapshot()