### PR TITLE
JavaFX and MathML. #71

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
@@ -159,6 +159,14 @@ final class WCFontImpl extends WCFont {
     @Override public double getGlyphWidth(int glyph) {
         return getFontStrike().getFontResource().getAdvance(glyph, font.getSize());
     }
+    
+    @Override public float[] getGlyphBoundingBox(int glyph) {
+        float[] bb = new float[4];
+        bb = getFontStrike().getFontResource().getGlyphBoundingBox(glyph, font.getSize(), bb);
+        bb[1]= -getAscent();
+        bb[3]= getDescent()-bb[1];
+        return bb;
+    }
 
     @Override public float getXHeight() {
         return getFontStrike().getMetrics().getXHeight();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
@@ -41,6 +41,8 @@ public abstract class WCFont extends Ref {
     public abstract float getXHeight();
 
     public abstract double getGlyphWidth(int glyph);
+    
+    public abstract float[] getGlyphBoundingBox(int glyph);
 
     public abstract double[] getStringBounds(String str, int from, int to,
                                              boolean rtl);

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
@@ -100,6 +100,13 @@ public final class WCFontPerfLogger extends WCFont {
         logger.suspendCount("GETGLYPHWIDTH");
         return res;
     }
+    
+    public float[] getGlyphBoundingBox(int glyph) {
+        logger.resumeCount("GETGLYPHBOUNDINGBOX");
+        float[] res = fnt.getGlyphBoundingBox(glyph);
+        logger.suspendCount("GETGLYPHBOUNDINGBOX");
+        return res;
+    }    
 
     public double getStringWidth(String str) {
         logger.resumeCount("GETSTRINGLENGTH");

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
@@ -140,9 +140,27 @@ float Font::platformWidthForGlyph(Glyph c) const
     return res;
 }
 
-FloatRect Font::platformBoundsForGlyph(Glyph) const
-{
-    return FloatRect(); //That is OK! platformWidthForGlyph impl is enough.
+FloatRect Font::platformBoundsForGlyph(Glyph c) const
+    {
+    //return FloatRect(); //That is OK! platformWidthForGlyph impl is enough.
+    
+    JNIEnv* env = WebCore_GetJavaEnv();
+
+    RefPtr<RQRef> jFont = m_platformData.nativeFontData();
+    if (!jFont) {
+        return FloatRect();
+    }
+
+    static jmethodID getGlyphBoundingBox_mID = env->GetMethodID(PG_GetFontClass(env), "getGlyphBoundingBox", "(I)[F");
+    ASSERT(getGlyphBoundingBox_mID);
+
+    jfloatArray boundingBox = (jfloatArray)env->CallObjectMethod(*jFont, getGlyphBoundingBox_mID, (jint)c);
+    
+    jfloat *bBox = env->GetFloatArrayElements(boundingBox,0);
+    
+    CheckAndClearException(env);
+
+    return FloatRect(bBox[0], bBox[1], bBox[2], bBox[3]);
 }
 
 }

--- a/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest.java
@@ -1,0 +1,101 @@
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.web.HTMLEditor;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+public class OpenJFXMathMLRenderingIssueTest extends Application {
+
+    final HTMLEditor htmlEditor = new HTMLEditor();
+    final StackPane root = new StackPane();
+
+    public void init() {
+        htmlEditor.setHtmlText(content);
+        WebView webView = (WebView) htmlEditor.lookup(".web-view");
+        WebEngine we = webView.getEngine();
+        root.getChildren().add(htmlEditor);
+        htmlEditor.setPrefWidth(400);
+        htmlEditor.setPrefHeight(150);
+        webView.focusedProperty().addListener((observable, oldValue, newValue) -> {
+            //webView.sethtmlEditor.setHtmlText(content);
+
+            if (newValue) {
+                webView.getBoundsInParent().toString();
+
+                int height = (int) we.executeScript(
+                        "elements = document.getElementsByTagName('mo');"
+                        + "element = elements[0].clientHeight;"
+                );
+                if (height < 2) {
+                    throw new RuntimeException("Bad");
+                }
+
+                System.out.println("Ok");
+            }
+        });
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+
+        primaryStage.setTitle("OpenJFX MathML Rendering Issue Test");
+        primaryStage.setScene(new Scene(root));
+        primaryStage.show();
+
+        //htmlEditor.setHtmlText(content);
+        //NodeList nl = we.getDocument().getElementsByTagName("mo");
+        //webView.getHeight()
+    }
+    /**
+     * @param args the command line arguments
+     */
+    /*public static void main(String[] args) {
+        launch(args);
+    }*/
+    String BodyContent
+            = "<math display=\"block\">"
+            + "   <mrow>"
+            + "      <mi>x</mi>"
+            + "      <mo>=</mo>"
+            + "      <mfrac>"
+            + "         <mrow>"
+            + "            <mo>−</mo>"
+            + "            <mi>b</mi>"
+            + "            <mo>±</mo>"
+            + "            <msqrt>"
+            + "               <mrow>"
+            + "                  <msup>"
+            + "                     <mi>b</mi>"
+            + "                     <mn>2</mn>"
+            + "                  </msup>"
+            + "                  <mo>−</mo>"
+            + "                  <mn>4</mn>"
+            + "                  <mi>a</mi>"
+            + "                  <mi>c</mi>"
+            + "               </mrow>"
+            + "            </msqrt>"
+            + "         </mrow>"
+            + "         <mrow>"
+            + "            <mn>2</mn>"
+            + "            <mi>a</mi>"
+            + "         </mrow>"
+            + "      </mfrac>"
+            + "   </mrow>"
+            + "</math>";
+
+    String content = "<!doctype html>"
+            + "<html>"
+            + "   <head>"
+            + "      <meta charset=\"UTF-8\">"
+            + "      <title>OpenJFX and MathML</title>"
+            + "   </head>"
+            + "   <body>"
+            + "      <p>"
+            + BodyContent
+            + "      </p>"
+            + "   </body>"
+            + "</html>";
+
+}


### PR DESCRIPTION
Hi !

Please could you review this patch.
The remaining problems are due to the missing OpenMathData table support .
A quick solution would be :
- to include a font file containing the right glyph alignment.
- and modify the mathml.css file to force MathML renderer to use them first.

Best regards.