### PR TITLE
JDK-8147476 : Rendering issues with MathML token elements.

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
@@ -159,6 +159,14 @@ final class WCFontImpl extends WCFont {
     @Override public double getGlyphWidth(int glyph) {
         return getFontStrike().getFontResource().getAdvance(glyph, font.getSize());
     }
+    
+    @Override public float[] getGlyphBoundingBox(int glyph) {
+        float[] bb = new float[4];
+        bb = getFontStrike().getFontResource().getGlyphBoundingBox(glyph, font.getSize(), bb);
+        bb[1]= -getAscent();
+        bb[3]= getDescent()-bb[1];
+        return bb;
+    }
 
     @Override public float getXHeight() {
         return getFontStrike().getMetrics().getXHeight();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
@@ -41,6 +41,8 @@ public abstract class WCFont extends Ref {
     public abstract float getXHeight();
 
     public abstract double getGlyphWidth(int glyph);
+    
+    public abstract float[] getGlyphBoundingBox(int glyph);
 
     public abstract double[] getStringBounds(String str, int from, int to,
                                              boolean rtl);

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
@@ -100,6 +100,13 @@ public final class WCFontPerfLogger extends WCFont {
         logger.suspendCount("GETGLYPHWIDTH");
         return res;
     }
+    
+    public float[] getGlyphBoundingBox(int glyph) {
+        logger.resumeCount("GETGLYPHBOUNDINGBOX");
+        float[] res = fnt.getGlyphBoundingBox(glyph);
+        logger.suspendCount("GETGLYPHBOUNDINGBOX");
+        return res;
+    }    
 
     public double getStringWidth(String str) {
         logger.resumeCount("GETSTRINGLENGTH");

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
@@ -140,9 +140,27 @@ float Font::platformWidthForGlyph(Glyph c) const
     return res;
 }
 
-FloatRect Font::platformBoundsForGlyph(Glyph) const
-{
-    return FloatRect(); //That is OK! platformWidthForGlyph impl is enough.
+FloatRect Font::platformBoundsForGlyph(Glyph c) const
+    {
+    //return FloatRect(); //That is OK! platformWidthForGlyph impl is enough.
+    
+    JNIEnv* env = WebCore_GetJavaEnv();
+
+    RefPtr<RQRef> jFont = m_platformData.nativeFontData();
+    if (!jFont) {
+        return FloatRect();
+    }
+
+    static jmethodID getGlyphBoundingBox_mID = env->GetMethodID(PG_GetFontClass(env), "getGlyphBoundingBox", "(I)[F");
+    ASSERT(getGlyphBoundingBox_mID);
+
+    jfloatArray boundingBox = (jfloatArray)env->CallObjectMethod(*jFont, getGlyphBoundingBox_mID, (jint)c);
+    
+    jfloat *bBox = env->GetFloatArrayElements(boundingBox,0);
+    
+    CheckAndClearException(env);
+
+    return FloatRect(bBox[0], bBox[1], bBox[2], bBox[3]);
 }
 
 }

--- a/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/OpenJFXMathMLRenderingIssueTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.web.HTMLEditor;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+/**
+ * @test
+ * @bug JDK-8147476 Rendering issues with MathML token elements
+ * @bug JDK-8089878 HTMLEditor messes up MathML markup press
+ */
+public class OpenJFXMathMLRenderingIssueTest extends Application {
+
+    final HTMLEditor htmlEditor = new HTMLEditor();
+    final StackPane root = new StackPane();
+    final WebView webView = (WebView) htmlEditor.lookup(".web-view");
+
+    public void init() {
+        htmlEditor.setHtmlText(content);
+        root.getChildren().add(htmlEditor);
+        htmlEditor.setPrefWidth(400);
+        htmlEditor.setPrefHeight(150);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+
+        webView.focusedProperty().addListener((observable, oldValue, newValue) -> {
+
+            if (newValue) {
+                webView.getBoundsInParent().toString();
+
+                WebEngine we = webView.getEngine();
+                int height = (int) we.executeScript(
+                        "elements = document.getElementsByTagName('mo');"
+                        + "element = elements[0].clientHeight;"
+                );
+
+                if (height < 2) {
+                    Platform.exit();
+                    throw new RuntimeException(" : MathML rendering issues see JDK-8089878 and JDK-8147476.\n");
+                }
+
+                System.out.println("[Ok]\n");
+                Platform.exit();
+            }
+        });
+
+        primaryStage.setTitle("OpenJFX MathML Rendering Issue Test");
+        primaryStage.setScene(new Scene(root));
+        primaryStage.show();
+
+    }
+    /**
+     * @param args the command line arguments
+     */
+    /*public static void main(String[] args) {
+        launch(args);
+    }*/
+    String BodyContent
+            = "<math display=\"block\">"
+            + "   <mrow>"
+            + "      <mi>x</mi>"
+            + "      <mo>=</mo>"
+            + "      <mfrac>"
+            + "         <mrow>"
+            + "            <mo>−</mo>"
+            + "            <mi>b</mi>"
+            + "            <mo>±</mo>"
+            + "            <msqrt>"
+            + "               <mrow>"
+            + "                  <msup>"
+            + "                     <mi>b</mi>"
+            + "                     <mn>2</mn>"
+            + "                  </msup>"
+            + "                  <mo>−</mo>"
+            + "                  <mn>4</mn>"
+            + "                  <mi>a</mi>"
+            + "                  <mi>c</mi>"
+            + "               </mrow>"
+            + "            </msqrt>"
+            + "         </mrow>"
+            + "         <mrow>"
+            + "            <mn>2</mn>"
+            + "            <mi>a</mi>"
+            + "         </mrow>"
+            + "      </mfrac>"
+            + "   </mrow>"
+            + "</math>";
+
+    String content = "<!doctype html>"
+            + "<html>"
+            + "   <head>"
+            + "      <meta charset=\"UTF-8\">"
+            + "      <title>OpenJFX and MathML</title>"
+            + "   </head>"
+            + "   <body>"
+            + "      <p>"
+            + BodyContent
+            + "      </p>"
+            + "   </body>"
+            + "</html>";
+
+}


### PR DESCRIPTION
Hi !

Please could you review this patch.
- This is tracked in JBS as 
  - [JDK-8147476](https://bugs.openjdk.java.net/browse/JDK-8147476?jql=text%20~%20"Mathml") Rendering issues with MathML token elements.
  - [JDK-8165520](https://bugs.openjdk.java.net/browse/JDK-8165520?jql=text%20~%20Mathml%20ORDER%20BY%20created%20DESC%2C%20due%20DESC%2C%20cf%5B10710%5D%20ASC) Several mathml/ DRT tests fail
  - [JDK-8089878](https://bugs.openjdk.java.net/browse/JDK-8089878?jql=text%20~%20Mathml%20ORDER%20BY%20created%20DESC%2C%20due%20DESC%2C%20cf%5B10710%5D%20ASC) HTMLEditor messes up MathML markup.
- Issue #71  was submitted for this.

The remaining problems are due to the missing OpenMathData table support .
A quick solution would be :

-  to include a font file containing the right glyph alignment.
-  and modify the mathml.css file to force MathML renderer to use them first.

Best regards.

------------------------------------------------------------------------------------------------------

commit 726cb328783b2e501695e04519cbf9cc694694e4
Author: Guy Abossolo Foh <info@scientificware.com>
Date:   Sun Jun 17 15:00:46 2018 +0200

    Update OpenJFXMathMLRenderingIssueTest.java issue 22

commit f9164fd6ca036464b81edb39bafe946584d284c5
Author: Guy Abossolo Foh <info@scientificware.com>
Date:   Sat Jun 16 18:05:00 2018 +0200

    Validation branche WebCorePatch2018061617