### PR TITLE
JDK-8147476 : Rendering issues with MathML token elements.

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCFontImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,12 @@ final class WCFontImpl extends WCFont {
 
     @Override public double getGlyphWidth(int glyph) {
         return getFontStrike().getFontResource().getAdvance(glyph, font.getSize());
+    }
+
+    @Override public float[] getGlyphBoundingBox(int glyph) {
+        float[] bb = new float[4];
+        bb = getFontStrike().getFontResource().getGlyphBoundingBox(glyph, font.getSize(), bb);
+        return new float[]{bb[0], -bb[3], bb[2], bb[3] - bb[1]};
     }
 
     @Override public float getXHeight() {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ public abstract class WCFont extends Ref {
     public abstract float getXHeight();
 
     public abstract double getGlyphWidth(int glyph);
+
+    public abstract float[] getGlyphBoundingBox(int glyph);
 
     public abstract double[] getStringBounds(String str, int from, int to,
                                              boolean rtl);

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCFontPerfLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,13 @@ public final class WCFontPerfLogger extends WCFont {
         logger.resumeCount("GETGLYPHWIDTH");
         double res = fnt.getGlyphWidth(glyph);
         logger.suspendCount("GETGLYPHWIDTH");
+        return res;
+    }
+
+    public float[] getGlyphBoundingBox(int glyph) {
+        logger.resumeCount("GETGLYPHBOUNDINGBOX");
+        float[] res = fnt.getGlyphBoundingBox(glyph);
+        logger.suspendCount("GETGLYPHBOUNDINGBOX");
         return res;
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,9 +140,24 @@ float Font::platformWidthForGlyph(Glyph c) const
     return res;
 }
 
-FloatRect Font::platformBoundsForGlyph(Glyph) const
+FloatRect Font::platformBoundsForGlyph(Glyph c) const
 {
-    return FloatRect(); //That is OK! platformWidthForGlyph impl is enough.
+    JNIEnv* env = WebCore_GetJavaEnv();
+
+    RefPtr<RQRef> jFont = m_platformData.nativeFontData();
+    if (!jFont) {
+        return {};
+    }
+
+    static jmethodID getGlyphBoundingBox_mID = env->GetMethodID(PG_GetFontClass(env), "getGlyphBoundingBox", "(I)[F");
+    ASSERT(getGlyphBoundingBox_mID);
+
+    jfloatArray boundingBox = (jfloatArray)env->CallObjectMethod(*jFont, getGlyphBoundingBox_mID, (jint)c);
+    jfloat *bBox = env->GetFloatArrayElements(boundingBox,0);
+    auto bb = FloatRect { bBox[0], bBox[1], bBox[2], bBox[3] };
+    env->ReleaseFloatArrayElements(boundingBox, bBox, 0);
+    CheckAndClearException(env);
+    return bb;
 }
 
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MathMLRenderTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MathMLRenderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class MathMLRenderTest extends TestBase {
+
+    @Test public void testTokenHeight() throws Exception {
+        loadContent("<!doctype html><html><body><math><mo>=</mo></math></body></html>");
+        int height = (int) executeScript("document.getElementsByTagName('mo')[0].clientHeight");
+        assertTrue("MathML token height is lesser than expected " + height, height > 1);
+    }
+}


### PR DESCRIPTION
Hi !

This is tracked in JBS as 
- [JDK-8147476](https://bugs.openjdk.java.net/browse/JDK-8147476?jql=text%20~%20"Mathml") Rendering issues with MathML token elements.
- [JDK-8165520](https://bugs.openjdk.java.net/browse/JDK-8165520?jql=text%20~%20Mathml%20ORDER%20BY%20created%20DESC%2C%20due%20DESC%2C%20cf%5B10710%5D%20ASC) Several mathml/ DRT tests fail
- [JDK-8089878](https://bugs.openjdk.java.net/browse/JDK-8089878?jql=text%20~%20Mathml%20ORDER%20BY%20created%20DESC%2C%20due%20DESC%2C%20cf%5B10710%5D%20ASC) HTMLEditor messes up MathML markup.

- [JDK-8090887](https://bugs.openjdk.java.net/browse/JDK-8090887?jql=text%20~%20Mathml%20ORDER%20BY%20created%20DESC%2C%20due%20DESC%2C%20cf%5B10710%5D%20ASC) Support MathML.

Issue #71  was submitted for this.

Please could you review this patch :
Bug JDK-8147476, commit of the following :

FontJava.cpp :
 - Completes the implementation of the platformBoundsForGlyph(Glyph c) function in FontJava.cpp.
 - Previous implementation simply returned a (0,0,0,0) rectangle, which explains the bad rendering height of MathML elements.
 - This affects only MathML elements due to specific mathematic glyphs behavior : WebCore MathML rendering can't use the font ascents and descents which causes gap into assembled glyphs. So getAscent(), getDescent() ... font methods are not appropriate.
 - WebCore uses bearY and heights informations from the glyph bounding box.

MathMLRenderTest.java :
 - Adds a HeadLess proper unit test for this Bug JDK-8147476.
 - Tests the height of the first MathML mo token element in a quadratic formula.

WCFont.java :
 - Adds the abstract getGlyphBoundingBox() method.

WCFontPerfLogger.java :
 - Adds the getGlyphBoundingBox() method.

WCFontImpl.java :
 - Implements the getGlyphBoundingBox() method.
 - Uses and reorders (FontResource) getGlyphBoundingBox values to match perfectly with WebCore requirements.

All files :
 - Changes copyright date and removes white space tabulation.

With last small changes (comments #71) the rendering is far better than with my previous patch.  Now WebView is not so far from Safari and FireFox versus MathML display. The remaining problems are due to the missing OpenMathData table support.
A quick solution would be :

-  to include a font file containing the right glyph alignment.
-  and modify the mathml.css file to force MathML renderer to use them first.

Best regards.