### PR TITLE
JDK-8207370 Fix failing Monocle tests (deprecated assertEquals).

### DIFF
--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/TestApplication.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/TestApplication.java
@@ -365,8 +365,8 @@ public class TestApplication extends Application {
                 TestLogShim.log("y = " + robot.getMouseY());
                 TestLogShim.log("targetX = " + targetX);
                 TestLogShim.log("targetY = " + targetY);
-                Assert.assertEquals(targetX, robot.getMouseX());
-                Assert.assertEquals(targetY, robot.getMouseY());
+                Assert.assertEquals(targetX, (int) robot.getMouseX());
+                Assert.assertEquals(targetY, (int) robot.getMouseY());
             });
             frameWait(1);
         } finally {


### PR DESCRIPTION
I have not yet confirmed that this fixes all of the failures. In other words, I haven't actually run `gradle -PUNSTABLE_TEST=true` yet.

https://bugs.openjdk.java.net/browse/JDK-8207370