### PR TITLE
JDK-8207015: jlink javafx.graphics on Windows fails: PluginException: Duplicate resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5589,6 +5589,12 @@ compileTargets { t ->
         def standaloneSdkDir = "${rootProject.buildDir}/${standaloneSdkDirName}"
         def standaloneLegalDir = "${standaloneSdkDir}/legal"
 
+        def excludeDLLs = []
+        if (IS_WINDOWS) {
+            excludeDLLs += targetProperties.VS2017DLLNames
+            excludeDLLs += targetProperties.WinSDKDLLNames
+        }
+
         moduleProjList.each { project ->
             def moduleName = project.ext.moduleName
             def buildDir = project.buildDir
@@ -5612,6 +5618,13 @@ compileTargets { t ->
                         if (file(srcLibDir).isDirectory()) {
                             args("--libs")
                             args(srcLibDir)
+                        }
+                        // Exclude Microsoft DLLs from javafx.graphics.jmod
+                        if (moduleName == "javafx.graphics") {
+                            excludeDLLs.each { name ->
+                                args("--exclude")
+                                args(name)
+                            }
                         }
                         args("--legal-notices")
                         args(srcLegalDir)

--- a/build.gradle
+++ b/build.gradle
@@ -5589,10 +5589,11 @@ compileTargets { t ->
         def standaloneSdkDir = "${rootProject.buildDir}/${standaloneSdkDirName}"
         def standaloneLegalDir = "${standaloneSdkDir}/legal"
 
-        def excludeDLLs = []
+        def excludeNativeLibs = []
         if (IS_WINDOWS) {
-            excludeDLLs += targetProperties.VS2017DLLNames
-            excludeDLLs += targetProperties.WinSDKDLLNames
+            // List of duplicate Microsoft DLLs to exclude
+            excludeNativeLibs += targetProperties.VS2017DLLNames
+            excludeNativeLibs += targetProperties.WinSDKDLLNames
         }
 
         moduleProjList.each { project ->
@@ -5619,9 +5620,9 @@ compileTargets { t ->
                             args("--libs")
                             args(srcLibDir)
                         }
-                        // Exclude Microsoft DLLs from javafx.graphics.jmod
+                        // Exclude duplicate native libs from javafx.graphics.jmod
                         if (moduleName == "javafx.graphics") {
-                            excludeDLLs.each { name ->
+                            excludeNativeLibs.each { name ->
                                 args("--exclude")
                                 args(name)
                             }

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -196,24 +196,26 @@ if (WINDOWS_VS_VER == "150") {
 
 def vs2017DllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
 if (file(vs2017DllPath).exists()) {
-    def VS2017DLLs = [
+    ext.WIN.VS2017DLLNames = [
         "concrt140.dll",
         "msvcp140.dll",
         "vcruntime140.dll"
     ];
     ext.WIN.VS2017DLLs = []
-        VS2017DLLs.each { vsdll->
-            ext.WIN.VS2017DLLs += "$vs2017DllPath/$vsdll"
-        }
+    ext.WIN.VS2017DLLNames.each { vsdll->
+        ext.WIN.VS2017DLLs += "$vs2017DllPath/$vsdll"
+    }
 }
 else {
+    ext.WIN.VS2017DLLNames = [
+	];
     ext.WIN.VS2017DLLs = [
 	];
 }
 
 def WinSDKDLLsPath = cygpath("${winSdkDllDir}")
 if (file(WinSDKDLLsPath).exists()) {
-    def WinSDKDLLs = [
+    ext.WIN.WinSDKDLLNames = [
         "api-ms-win-core-console-l1-1-0.dll",
         "api-ms-win-core-datetime-l1-1-0.dll",
         "api-ms-win-core-debug-l1-1-0.dll",
@@ -257,11 +259,13 @@ if (file(WinSDKDLLsPath).exists()) {
         "ucrtbase.dll"
     ];
     ext.WIN.WinSDKDLLs = []
-        WinSDKDLLs.each { winsdkdll->
-            ext.WIN.WinSDKDLLs += "$WinSDKDLLsPath/$winsdkdll"
-        }
+    ext.WIN.WinSDKDLLNames.each { winsdkdll->
+        ext.WIN.WinSDKDLLs += "$WinSDKDLLsPath/$winsdkdll"
+    }
 }
 else {
+    ext.WIN.WinSDKDLLNames = [
+    ];
     ext.WIN.WinSDKDLLs = [
     ];
 }


### PR DESCRIPTION
[JDK-8207015](https://bugs.openjdk.java.net/browse/JDK-8207015) : jlink javafx.graphics on Windows fails: PluginException: Duplicate resources
