### PR TITLE
WIP: JDK-8208649 - FXCanvas / JFXPanel: Windows opened are not children of the SWT/Swing Window

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -562,6 +562,10 @@ public abstract class Application {
      * type.
      */
     public abstract Window createWindow(Window owner, Screen screen, int styleMask);
+    
+    public Window createWindow(long owner, Screen screen, int styleMask) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Create a window.

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -43,6 +43,12 @@ class GtkWindow extends Window {
 
     @Override
     protected native long _createWindow(long ownerPtr, long screenPtr, int mask);
+    
+    @Override
+    protected long _createEmbeddedWindow(long ownerPtr, long screenPtr, int mask) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
 
     @Override
     protected native long _createChildWindow(long parent);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
@@ -70,6 +70,10 @@ final class IosWindow extends Window {
     @Override native protected void _exitModal(long ptr);
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);
+    @Override
+    protected long _createEmbeddedWindow(long ownerPtr, long screenPtr, int mask) {
+        throw new UnsupportedOperationException();
+    }
 
     //No cursor on iOS. API compatibility call.
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -187,6 +187,11 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     @Override public Window createWindow(Window owner, Screen screen, int styleMask) {
         return new MacWindow(owner, screen, styleMask);
     }
+    
+    @Override
+    public Window createWindow(long owner, Screen screen, int styleMask) {
+        return new MacWindow(owner, screen, styleMask);
+    }
 
     final static long BROWSER_PARENT_ID = -1L;
     @Override public Window createWindow(long parent) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -49,11 +49,15 @@ final class MacWindow extends Window {
     protected MacWindow(Window owner, Screen screen, int styleMask) {
         super(owner, screen, styleMask);
     }
+    protected MacWindow(long parent, Screen screen, int styleMask) {
+        super(parent, screen, styleMask);
+    }
     protected MacWindow(long parent) {
         super(parent);
     }
 
     @Override native protected long _createWindow(long ownerPtr, long screenPtr, int mask);
+    @Override native protected long _createEmbeddedWindow(long ownerPtr, long screenPtr, int mask);
     @Override native protected long _createChildWindow(long parent);
     @Override native protected boolean _close(long ptr);
     @Override native protected boolean _setView(long ptr, View view);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -166,6 +166,11 @@ final class MonocleWindow extends Window {
         id = MonocleWindowManager.getInstance().addWindow(this);
         return id;
     }
+    
+    @Override
+    protected long _createEmbeddedWindow(long ownerPtr, long screenPtr, int mask) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     protected long _createChildWindow(long parent) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -252,6 +252,11 @@ class WinWindow extends Window {
     native private long _getInsets(long ptr);
     native private long _getAnchor(long ptr);
     @Override native protected long _createWindow(long ownerPtr, long screenPtr, int mask);
+    @Override
+    protected long _createEmbeddedWindow(long ownerPtr, long screenPtr, int mask) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
     @Override native protected long _createChildWindow(long parent);
     @Override native protected boolean _close(long ptr);
     @Override native protected boolean _setView(long ptr, View view);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/embed/HostInterface.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/embed/HostInterface.java
@@ -140,4 +140,6 @@ public interface HostInterface {
      * @see #grabFocus
      */
     public void ungrabFocus();
+    
+    public long getWindowHandle();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
@@ -318,6 +318,7 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
         /* Perhaps this could return the ID for the window in which this
          * stage is embedded, but there is no current requirement for that.
          */
-        return 0L;
+        long handle = host.getWindowHandle();
+        return handle;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -194,8 +194,15 @@ class WindowStage extends GlassStage {
                             break;
                     }
                 }
-                platformWindow =
-                        app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
+                
+                if( ownerWindow == null && owner != null ) {
+                    platformWindow =
+                            app.createWindow(owner.getRawHandle(), Screen.getMainScreen(), windowMask);
+                } else {
+                    platformWindow =
+                            app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
+                }
+                
                 platformWindow.setResizable(resizable);
                 platformWindow.setFocusable(focusable);
                 if (securityDialog) {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -748,6 +748,19 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_mac_MacWindow__1createWindow
     return _createWindowCommon(env, jWindow, jOwnerPtr, jScreenPtr, jStyleMask, JNI_FALSE);
 }
 
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_mac_MacWindow__1createEmbeddedWindow
+(JNIEnv *env, jobject jWindow, jlong jOwnerPtr, jlong jScreenPtr, jint jStyleMask) 
+{
+   jlong window = _createWindowCommon(env, jWindow, 0L, jScreenPtr, jStyleMask, JNI_FALSE);
+   GlassEmbeddedWindow *gWindow = getGlassEmbeddedWindow(env, window);
+   NSWindow *oWindow = (NSWindow*)jlong_to_ptr(jOwnerPtr);
+   [oWindow addChildWindow:gWindow ordered:1];
+   // gWindow->parent = oWindow;
+   
+   return window;
+}
+  
+
 /*
  * Class:     com_sun_glass_ui_mac_MacWindow
  * Method:    _createChildWindow

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -1076,5 +1076,10 @@ public class JFXPanel extends JComponent {
                 }
             });
         }
+
+        @Override
+        public long getWindowHandle() {
+            return 0L;
+        }
     }
 }

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
@@ -368,6 +368,21 @@ public class FXCanvas extends Canvas {
         Platform.runLater(()-> Application.GetApplication().setName(name));
     }
 
+    // Work around because SWT does not send reparent events but Control#setParent
+    // calls reskin(SWT.ALL) so this implementation detail can be used to update
+    // the current x/y position of the embedded stage
+    //
+    // There are other situations where reskin() is called but they are not frequent
+    // and the only harm is that we potentially recompute the location although it did
+    // not change in reality
+    @Override
+    public void reskin(int flags) {
+        super.reskin(flags);
+        if (flags == SWT.ALL) {
+            sendMoveEventToFX();
+        }
+    }
+
     static ArrayList<DropTarget> targets = new ArrayList<>();
 
     DropTarget getDropTarget() {

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
@@ -170,6 +170,20 @@ public class FXCanvas extends Canvas {
             control = control.getParent();
         };
     };
+    
+    private long getWindowHandle() {
+        if (SWT.getPlatform().equals("cocoa")) {
+            try {
+                Object nsWindow = windowField.get(this.getShell());
+                Long ptr = ((Number) idField.get(nsWindow)).longValue();
+                return ptr;
+            } catch (Throwable e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+        return 0;
+    }
 
     private double getScaleFactor() {
         if (SWT.getPlatform().equals("cocoa")) {
@@ -232,6 +246,7 @@ public class FXCanvas extends Canvas {
     }
 
     private static Field windowField;
+    private static Field idField;
     private static Method windowMethod;
     private static Method screenMethod;
     private static Method backingScaleFactorMethod;
@@ -242,6 +257,9 @@ public class FXCanvas extends Canvas {
             try {
                 windowField = Shell.class.getDeclaredField("window");
                 windowField.setAccessible(true);
+                
+                Class idClass = Class.forName("org.eclipse.swt.internal.cocoa.id");
+                idField = idClass.getDeclaredField("id");
 
                 Class nsViewClass = Class.forName("org.eclipse.swt.internal.cocoa.NSView");
                 windowMethod = nsViewClass.getDeclaredMethod("window");
@@ -281,6 +299,7 @@ public class FXCanvas extends Canvas {
         registerEventListeners();
         Display display = parent.getDisplay();
         display.addFilter(SWT.Move, moveFilter);
+        System.err.println("=========> WINDOW: " + getWindowHandle());
     }
 
     /**
@@ -1064,6 +1083,11 @@ public class FXCanvas extends Canvas {
 
         final FXCanvas fxCanvas = FXCanvas.this;
 
+        @Override
+        public long getWindowHandle() {
+            return fxCanvas.getWindowHandle();
+        }
+        
         @Override
         public void setEmbeddedStage(EmbeddedStageInterface embeddedStage) {
             stagePeer = embeddedStage;


### PR DESCRIPTION
This is a  first PoC on passing the native pointer from SWT to JavaFX to see if this can be done and would work. Currently this is just hacked into the OS-X Version but if @kevinrushforth agrees that this would be feasable the next step would be to get this working on Linux and Windows and improve the implementation. 

The following things need to be considered:
* what happens to sub-windows if the JFXPanel/FXCanvas is reparented on to another window. Do we need to reparent them as well or would be ok to just close them?
* find out why the color-picker popup initially moves but if you hover on it, it repositions on the old coordinates