### PR TITLE
JDK-8207328 Fix Stylesheet Javadocs

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -67,7 +67,7 @@ public class Stylesheet {
 
     private final String url;
     /** The URL from which the stylesheet was loaded.
-     * @return The URL from which the stylesheet was loaded, or null if
+     * @return A String version of the URL from which the stylesheet was loaded, or null if
      *         the stylesheet was created from an inline style.
      */
     public String getUrl() {
@@ -238,7 +238,7 @@ public class Stylesheet {
     private String[] stringStore;
     final String[] getStringStore() { return stringStore; }
 
-    /** Load a binary stylesheet file from a input stream.
+    /** Loads a binary stylesheet from a URL.
      * @param url the URL from which the stylesheet will be loaded
      * @return the constructed stylesheet
      * @throws java.io.IOException the exception
@@ -293,9 +293,9 @@ public class Stylesheet {
     }
 
     /**
-     * Convert the .css file referenced by urlIn to binary format and write to urlOut.
-     * @param source is the JavaFX .css file to convert
-     * @param destination is the file to which the binary conversion is written
+     * Convert the .css file referenced by source to binary format and write to destination.
+     * @param source the JavaFX .css file to convert
+     * @param destination the file to which the binary version is written
      * @throws IOException the exception
      * @throws IllegalArgumentException if either parameter is null, if source and destination are the same,
      * if source cannot be read, or if destination cannot be written.

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -67,7 +67,7 @@ public class Stylesheet {
 
     private final String url;
     /** The URL from which the stylesheet was loaded.
-     * @return A String version of the URL from which the stylesheet was loaded, or null if
+     * @return A String representation of the URL from which the stylesheet was loaded, or null if
      *         the stylesheet was created from an inline style.
      */
     public String getUrl() {
@@ -131,9 +131,9 @@ public class Stylesheet {
     }
 
     /**
-     * Constructs a Stylesheet using the given URL as the base URI. The
+     * Constructs a Stylesheet interpreting the given String as the base URI. The
      * parameter may not be null.
-     * @param url
+     * @param url the base URI for this stylesheet.
      */
     Stylesheet(String url) {
 
@@ -239,9 +239,10 @@ public class Stylesheet {
     final String[] getStringStore() { return stringStore; }
 
     /** Loads a binary stylesheet from a URL.
-     * @param url the URL from which the stylesheet will be loaded
-     * @return the constructed stylesheet
-     * @throws java.io.IOException the exception
+     * @param url the URL from which the stylesheet will be loaded.
+     * @return the loaded stylesheet.
+     * @throws java.io.IOException if the binary stream corresponds to a more recent binary
+     * css version or if any other IO error occurs while reading from the stream.
      */
     public static Stylesheet loadBinary(URL url) throws IOException {
 
@@ -296,7 +297,7 @@ public class Stylesheet {
      * Convert the .css file referenced by source to binary format and write to destination.
      * @param source the JavaFX .css file to convert
      * @param destination the file to which the binary version is written
-     * @throws IOException the exception
+     * @throws IOException if the destination file can not be created or any other IO error occurs.
      * @throws IllegalArgumentException if either parameter is null, if source and destination are the same,
      * if source cannot be read, or if destination cannot be written.
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -66,7 +66,9 @@ public class Stylesheet {
     final static int BINARY_CSS_VERSION = 6;
 
     private final String url;
-    /** The URL from which the stylesheet was loaded.
+    /**
+     *  The URL from which this {@code Stylesheet} was loaded.
+     *
      * @return A String representation of the URL from which the stylesheet was loaded, or null if
      *         the stylesheet was created from an inline style.
      */
@@ -75,11 +77,17 @@ public class Stylesheet {
     }
 
     /**
-     * True if this style came from user stylesheet, we need to know this so
+     * Specifies the origin of this {@code Stylesheet}. We need to know this so
      * that we can make user important styles have higher priority than
-     * author styles
+     * author styles.
      */
     private StyleOrigin origin = StyleOrigin.AUTHOR;
+
+    /**
+     * The origin of this {@code Stylesheet}.
+     *
+     * @return the origin of this {@code Stylesheet}
+     */
     public StyleOrigin getOrigin() {
         return origin;
     }
@@ -131,9 +139,10 @@ public class Stylesheet {
     }
 
     /**
-     * Constructs a Stylesheet interpreting the given String as the base URI. The
+     * Constructs a Stylesheet using the given URL as the base URI. The
      * parameter may not be null.
-     * @param url the base URI for this stylesheet.
+     *
+     * @param url the base URI for this stylesheet
      */
     Stylesheet(String url) {
 
@@ -141,10 +150,20 @@ public class Stylesheet {
 
     }
 
+    /**
+     * The rules that are defined in this {@code Stylesheet}
+     *
+     * @return a list of rules used by this {@code Stylesheet}
+     */
     public List<Rule> getRules() {
         return rules;
     }
 
+    /**
+     * The font faces used by this {@code Stylesheet}
+     *
+     * @return a list of font faces used by this {@code Stylesheet}
+     */
     public List<FontFace> getFontFaces() {
         return fontFaces;
     }
@@ -238,11 +257,13 @@ public class Stylesheet {
     private String[] stringStore;
     final String[] getStringStore() { return stringStore; }
 
-    /** Loads a binary stylesheet from a URL.
-     * @param url the URL from which the stylesheet will be loaded.
-     * @return the loaded stylesheet.
-     * @throws java.io.IOException if the binary stream corresponds to a more recent binary
-     * css version or if any other IO error occurs while reading from the stream.
+    /**
+     * Loads a binary stylesheet from a URL.
+     *
+     * @param url the URL from which the {@code Stylesheet} will be loaded
+     * @return the loaded {@code Stylesheet}
+     * @throws IOException if the binary stream corresponds to a more recent binary
+     * css version or if an I/O error occurs while reading from the stream
      */
     public static Stylesheet loadBinary(URL url) throws IOException {
 
@@ -294,12 +315,14 @@ public class Stylesheet {
     }
 
     /**
-     * Convert the .css file referenced by source to binary format and write to destination.
-     * @param source the JavaFX .css file to convert
-     * @param destination the file to which the binary version is written
-     * @throws IOException if any IO error occurs.
-     * @throws IllegalArgumentException if either parameter is null, if source and destination are the same,
-     * if source cannot be read, or if destination cannot be written.
+     * Convert the css file referenced by source to binary format and write to destination.
+     *
+     * @param source the JavaFX compliant css file to convert
+     * @param destination the file to which the binary formatted data is written
+     * @throws IOException if the destination file can not be created or if an I/O error occurs
+     * @throws IllegalArgumentException if either parameter is null, if {@code source} and
+     * {@code destination} are the same, if {@code source} cannot be read, or if {@code destination}
+     * cannot be written
      */
     public static void convertToBinary(File source, File destination) throws IOException {
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class Stylesheet {
     /**
      *  The URL from which this {@code Stylesheet} was loaded.
      *
-     * @return A String representation of the URL from which the stylesheet was loaded, or null if
+     * @return A {@code String} representation of the URL from which the stylesheet was loaded, or {@code null} if
      *         the stylesheet was created from an inline style.
      */
     public String getUrl() {
@@ -151,7 +151,7 @@ public class Stylesheet {
     }
 
     /**
-     * The rules that are defined in this {@code Stylesheet}
+     * Returns the rules that are defined in this {@code Stylesheet}
      *
      * @return a list of rules used by this {@code Stylesheet}
      */
@@ -160,7 +160,7 @@ public class Stylesheet {
     }
 
     /**
-     * The font faces used by this {@code Stylesheet}
+     * Returns the font faces used by this {@code Stylesheet}
      *
      * @return a list of font faces used by this {@code Stylesheet}
      */
@@ -258,9 +258,9 @@ public class Stylesheet {
     final String[] getStringStore() { return stringStore; }
 
     /**
-     * Loads a binary stylesheet from a URL.
+     * Loads a binary stylesheet from a {@code URL}.
      *
-     * @param url the URL from which the {@code Stylesheet} will be loaded
+     * @param url the {@code URL} from which the {@code Stylesheet} will be loaded
      * @return the loaded {@code Stylesheet}
      * @throws IOException if the binary stream corresponds to a more recent binary
      * css version or if an I/O error occurs while reading from the stream
@@ -315,12 +315,12 @@ public class Stylesheet {
     }
 
     /**
-     * Convert the css file referenced by source to binary format and write to destination.
+     * Converts the css file referenced by {@code source} to binary format and writes it to {@code destination}.
      *
      * @param source the JavaFX compliant css file to convert
      * @param destination the file to which the binary formatted data is written
      * @throws IOException if the destination file can not be created or if an I/O error occurs
-     * @throws IllegalArgumentException if either parameter is null, if {@code source} and
+     * @throws IllegalArgumentException if either parameter is {@code null}, if {@code source} and
      * {@code destination} are the same, if {@code source} cannot be read, or if {@code destination}
      * cannot be written
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -297,7 +297,7 @@ public class Stylesheet {
      * Convert the .css file referenced by source to binary format and write to destination.
      * @param source the JavaFX .css file to convert
      * @param destination the file to which the binary version is written
-     * @throws IOException if the destination file can not be created or any other IO error occurs.
+     * @throws IOException if any IO error occurs.
      * @throws IllegalArgumentException if either parameter is null, if source and destination are the same,
      * if source cannot be read, or if destination cannot be written.
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -84,7 +84,7 @@ public class Stylesheet {
     private StyleOrigin origin = StyleOrigin.AUTHOR;
 
     /**
-     * The origin of this {@code Stylesheet}.
+     * Returns the origin of this {@code Stylesheet}.
      *
      * @return the origin of this {@code Stylesheet}
      */
@@ -151,7 +151,7 @@ public class Stylesheet {
     }
 
     /**
-     * Returns the rules that are defined in this {@code Stylesheet}
+     * Returns the rules that are defined in this {@code Stylesheet}.
      *
      * @return a list of rules used by this {@code Stylesheet}
      */
@@ -160,7 +160,7 @@ public class Stylesheet {
     }
 
     /**
-     * Returns the font faces used by this {@code Stylesheet}
+     * Returns the font faces used by this {@code Stylesheet}.
      *
      * @return a list of font faces used by this {@code Stylesheet}
      */


### PR DESCRIPTION
I attempted to improve the javadoc comments a bit to more match the underlying code. While reading some of the code I noticed that for example in the `convertToBinary` some input / output stream might potentially not be closed properly. I would also like to fix that if desired.