### PR TITLE
JDK-8209764: JavaFX/Monocle - Partial Screen Capture Broken

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleRobot.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleRobot.java
@@ -214,7 +214,7 @@ class MonocleRobot extends GlassRobot {
             int colStop = Math.min(x + width, scrWidth);
             for (int row = y; row < rowStop; row++) {
                 for (int col = x; col < colStop; col++) {
-                    data[row * scrWidth + col] = buffer.get(row * scrWidth + col);
+                    data[(row - y) * (colStop - x) + (col - x)] = buffer.get(row * scrWidth + col);
                 }
             }
         }


### PR DESCRIPTION
When capturing a partial region of the screen the `data` array elements have the wrong positions. This leads to an ArrayIndexOutOfBoundsException.

I introduced this error in the robot public API pull request.

This PR fixes it so that the `data` array indices match the correct pixels from the screen buffer.