### PR TITLE
JDK-8209967: Bump minimum gradle version to 4.8 for JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1212,14 +1212,14 @@ if (Integer.parseInt(NUM_COMPILE_THREADS.toString()) < 1) {
     NUM_COMPILE_THREADS = 1
 }
 
-// Check for Gradle 4.8, error if < 4.3.
+// Check for Gradle 4.8, error if < 4.8.
 if (gradle.gradleVersion != "4.8") {
     def ver = gradle.gradleVersion.split("[\\.]");
     def gradleMajor = Integer.parseInt(ver[0]);
     def gradleMinor = Integer.parseInt(ver[1].split("[^0-9]")[0]);
     def err = "";
-    if (gradleMajor < 4 || (gradleMajor == 4 && gradleMinor < 3)) {
-        err = "Gradle version too old: ${gradle.gradleVersion}; must be at least 4.3"
+    if (gradleMajor < 4 || (gradleMajor == 4 && gradleMinor < 8)) {
+        err = "Gradle version too old: ${gradle.gradleVersion}; must be at least 4.8"
     }
 
     if (IS_GRADLE_VERSION_CHECK && err != "") {


### PR DESCRIPTION
Fixes [JDK-8209966](https://bugs.openjdk.java.net/browse/JDK-8209966).

This bumps the minimum gradle version to 4.8, which is the currently supported version (and is already the version used when running gradlew).