### PR TITLE
JDK-8209966: Update minimum boot JDK to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3795,10 +3795,8 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
         ]);
 
     doLast {
-        // FIXME: remove JDK 10 logic once minimum JDK is bumped to 11
-        def isBootJdk10 = jdkVersion.startsWith("10")
         projectsToDocument.each { p ->
-            def destDir = isBootJdk10 ? "$buildDir/javadoc" : "$buildDir/javadoc/${p.ext.moduleName}"
+            def destDir = "$buildDir/javadoc/${p.ext.moduleName}"
             copy {
                 from("$p.projectDir/src/main/docs") {
                     include "**/*.html"

--- a/build.properties
+++ b/build.properties
@@ -72,5 +72,5 @@ javadoc.header=JavaFX&nbsp;12
 #
 ##############################################################################
 
-jfx.build.jdk.version.min=10
-jfx.build.jdk.buildnum.min=46
+jfx.build.jdk.version.min=11
+jfx.build.jdk.buildnum.min=28


### PR DESCRIPTION
Fix for JBS issue [JDK-8209966](https://bugs.openjdk.java.net/browse/JDK-8209966).

Bump the minimum JDK version needed to build JavaFX to jdk-11+28.

Note that this will not change the `javac` `--source` or --target flags (which are controlled in build.gradle by the `'sourceCompatibility'` option), which will remain at 10.

This will allow us to implement the following follow-on issues:

1. Compile with `--source 11 --target 11`
2. Stop building the old javafx.swing implementation which relies on internal API (using qualified exports on the command line)
3. Stop redistributing the Microsoft VS2017 and Windows SDK DLLs (since they are present in JDK 11).