### PR TITLE
JDK-8210020: MAVEN_VERSION uses short release version for fcs builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -537,7 +537,7 @@ if (HUDSON_JOB_NAME == "not_hudson") {
 defineProperty("RELEASE_SUFFIX", relSuffix)
 defineProperty("RELEASE_VERSION_SHORT", "${RELEASE_VERSION}${RELEASE_SUFFIX}")
 defineProperty("RELEASE_VERSION_LONG", "${RELEASE_VERSION_SHORT}+${PROMOTED_BUILD_NUMBER}${relOpt}")
-defineProperty("MAVEN_VERSION", "$RELEASE_VERSION_LONG")
+defineProperty("MAVEN_VERSION", IS_MILESTONE_FCS ? "${RELEASE_VERSION_SHORT}" : "${RELEASE_VERSION_LONG}")
 
 // Check whether the COMPILE_TARGETS property has been specified (if so, it was done by
 // the user and not by this script). If it has not been defined then default


### PR DESCRIPTION
This PR resolves #176. The version for maven artifacts is set to the short release version when building a FCS release.