### PR TITLE
JDK-8210219: GlassClipboard.cpp fails to compile with newer versions of VS2017

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -29,6 +29,12 @@
 #include <hash_map>
 #include <hash_set>
 
+// The following is derived from _HASH_SEED, which is an internal constant from
+// include/xhash; since this is an internal constant we define our own rather
+// that relying on something that Microsoft could remove (and apparately has in
+// newer version of Visual C++)
+#define GLASS_HASH_SEED (size_t)0xdeadbeef
+
 #include "GlassApplication.h"
 #include "GlassClipboard.h"
 #include "GlassDnD.h"
@@ -83,7 +89,7 @@ size_t hash_value(const FORMATETC &fr)
     _Val += size_t(fr.ptd);
     _Val >>= 13;
     _Val += size_t(fr.tymed);
-    return _Val ^ _HASH_SEED;
+    return _Val ^ GLASS_HASH_SEED;
 }
 
 //NB! There are two suffixes for mimes:

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -31,8 +31,8 @@
 
 // The following is derived from _HASH_SEED, which is an internal constant from
 // include/xhash; since this is an internal constant we define our own rather
-// that relying on something that Microsoft could remove (and apparately has in
-// newer version of Visual C++)
+// than relying on something that Microsoft could remove (and apparently has in
+// newer versions of Visual C++)
 #define GLASS_HASH_SEED (size_t)0xdeadbeef
 
 #include "GlassApplication.h"


### PR DESCRIPTION
fixes #183 

[JDK-8210219](https://bugs.openjdk.java.net/browse/JDK-8210219)

Use our own "GLASS_HASH_SEED" constant instead of relying on an internal constant that can change out from under us (and apparently has).