### PR TITLE
Run checkWhiteSpace without -v option

### DIFF
--- a/.github/pr-check-whitespace.sh
+++ b/.github/pr-check-whitespace.sh
@@ -1,9 +1,5 @@
 #! /bin/bash
 
-echo ""
-echo "Checking for white space errors"
-echo ""
-
 if [ -z "$TRAVIS_BRANCH" ]; then
     echo "TRAVIS_BRANCH is undefined, skipping white-space check"
     exit 0
@@ -12,6 +8,16 @@ fi
 ROOTDIR=$(git rev-parse --show-toplevel)
 cd $ROOTDIR
 
-# Check all files changed as part of this pull request
-# FIXME: maybe remove the -v option at some point
-bash .github/pr-list-files.sh | bash tools/scripts/checkWhiteSpace -S -x -v
+echo ""
+echo "--- List of added or modified files"
+echo ""
+
+# List all files that are part of this pull request
+bash .github/pr-list-files.sh
+
+echo ""
+echo "--- Checking for white space errors"
+echo ""
+
+# Check all files that are part of this pull request
+bash .github/pr-list-files.sh | bash tools/scripts/checkWhiteSpace -S -x

--- a/.github/pr-list-files.sh
+++ b/.github/pr-list-files.sh
@@ -6,4 +6,4 @@ if [ -z "$TRAVIS_BRANCH" ]; then
 fi
 
 # Produce a list of added and modified files by a GitHub pull request
-git diff --name-only --diff-filter=AM $(git merge-base HEAD $TRAVIS_BRANCH)..HEAD
+git --no-pager diff --name-only --diff-filter=AM $(git merge-base HEAD $TRAVIS_BRANCH)..HEAD


### PR DESCRIPTION
fixes #188

In addition to separating out the listing of the files from the checking of the files, with the latter only showing the failures, I added the `--no-pager` option to `git diff` to allow it to run in the background without trying to access the terminal.