### PR TITLE
Fix pr-list-files.sh script so renamed files are checked for white-space erorrs

### DIFF
--- a/.github/pr-list-files.sh
+++ b/.github/pr-list-files.sh
@@ -6,4 +6,4 @@ if [ -z "$TRAVIS_BRANCH" ]; then
 fi
 
 # Produce a list of added and modified files by a GitHub pull request
-git --no-pager diff --name-only --diff-filter=AM $(git merge-base HEAD $TRAVIS_BRANCH)..HEAD
+git --no-pager diff --no-renames --name-only --diff-filter=AM $(git merge-base HEAD $TRAVIS_BRANCH)..HEAD


### PR DESCRIPTION
This PR fixes the bug described in issue #194.

The fix is to simply add the `--no-renames` option to `git diff` when producing the list of files added or modified by a PR.

The following experimental PRs show the before/after test results for this fix:

#195 -- inject errors and verify that the renamed files are missed (not checked)
#196 -- apply the proposed fix and verify that now the injected errors in the renamed files are caught