### PR TITLE
JDK-8210218: WebKit build fails with newer versions of VS 2017

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/Variant.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/Variant.h
@@ -1868,13 +1868,13 @@ struct __visitor_table{
         return __visitor(get<_Type>(__v));
     }
 
-    static const __func_type __trampoline[sizeof...(_Types)];
+    static constexpr __func_type __trampoline[sizeof...(_Types)]={
+        &__trampoline_func<_Types>...
+    };
 };
 
 template<typename _Visitor,typename ... _Types>
-const typename __visitor_table<_Visitor,_Types...>::__func_type __visitor_table<_Visitor,_Types...>::__trampoline[sizeof...(_Types)]={
-        &__trampoline_func<_Types>...
-    };
+constexpr typename __visitor_table<_Visitor,_Types...>::__func_type __visitor_table<_Visitor,_Types...>::__trampoline[sizeof...(_Types)];
 
 template<typename _Visitor,typename ... _Types>
 constexpr typename __visitor_return_type<_Visitor,_Types...>::__type


### PR DESCRIPTION
There is a problem in the newer version(VC 14.15.26726) MSVC compiler which causes multiple symbol definition error when using lambda expression type in a function pointer argument.

Problem is already reported to Visual Studio team and it is been discussed over [here](https://developercommunity.visualstudio.com/content/problem/325062/msvs-151526726-throws-multiple-definition-error-wh.html).

The proposed workaround is to use constexpr.