### PR TITLE
JDK-8210093: Build FX class files with -source 11 and -target 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1765,7 +1765,7 @@ allprojects {
     // All of our projects are java projects
 
     apply plugin: "java"
-    sourceCompatibility = 10
+    sourceCompatibility = 11
 
     // By default all of our projects require junit for testing so we can just
     // setup this dependency here.


### PR DESCRIPTION
Fix for JBS issue [JDK-8210093](https://bugs.openjdk.java.net/browse/JDK-8210093).

This will build the classes in the javafx.* modules with `-source 11` and `-target 11`, meaning that we can start to use JDK 11 language features. It will also cause a fast-fail if a down-rev JDK is used.