### PR TITLE
WIP: [RFC] JDK-8211038: Add css fadein/fadeout functions.

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -223,7 +223,7 @@
             }
 
             /* Color Table Styles */
-            div.colorsquare { 
+            div.colorsquare {
                 display:inline-block;
                 width:20em;
                 margin: 3px 3px
@@ -1529,9 +1529,9 @@
     <p>JavaFX supports some color computation functions. These compute new
       colors from input colors at the time the color style is applied. This
       enables a color theme to be specified using a single base color and to
-      have variant colors computed from that base color. There are two color
-      functions: derive() and ladder().</p>
-    <p class="grammar">&lt;derive&gt; | &lt;ladder&gt;</p>
+      have variant colors computed from that base color. There are four color
+      functions: derive(), ladder(), fadein() and fadeout().</p>
+    <p class="grammar">&lt;derive&gt; | &lt;ladder&gt; | &lt;fadein&gt; | &lt;fadeout&gt;</p>
     <p><strong>Derive </strong><span class="grammar" style="font-size: smaller;">&lt;derive&gt;</span></p>
     <p class="grammar">derive( <a href="#typecolor" class="typelink">&lt;color&gt;</a>
       , <a href="#typenumber" class="typelink">&lt;number&gt;</a>% )</p>
@@ -1576,6 +1576,22 @@
           href="#typecolor"
           class="typelink">&lt;color&gt;</a>
         ) ]+ </span></p>
+    <p><strong>Fadein </strong><span class="grammar" style="font-size: smaller;">&lt;fadein&gt;</span></p>
+    <p class="grammar">fadein( <a href="#typecolor" class="typelink">&lt;color&gt;</a>
+        , <a href="#typenumber" class="typelink">&lt;number&gt;</a>% )</p>
+    <p>The fadein function takes a color and computes a more opaque version of that color.
+        The second parameter is the opacity, ranging from 0% to 100%. Has no effect on
+        fully opaque colors.</p>
+    <p class="example">fadein(rgba(35, 70, 112, 0.8), 10%)</p>
+    <p>Will result in the color rgba(35, 70, 112, 0.88)</p>
+    <p><strong>Fadeout </strong><span class="grammar" style="font-size: smaller;">&lt;fadeout&gt;</span></p>
+    <p class="grammar">fadeout( <a href="#typecolor" class="typelink">&lt;color&gt;</a>
+        , <a href="#typenumber" class="typelink">&lt;number&gt;</a>% )</p>
+    <p>The fadeout functions takes a color and computes a more transparent version of that
+        color. The second parameter is the transparency, ranging from 0% to 100%. Has no effect
+        on fully transparent colors.</p>
+    <p class="example">fadeout(rgba(35, 70, 112, 0.8), 10%)</p>
+    <p>Will result in the color rgba(35, 70, 112, 0.72)</p>
     <h2><a id="stage">Stage</a></h2>
     <table class="package" width="100%">
         <tbody>

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -34,6 +34,8 @@ import javafx.css.converter.BooleanConverter;
 import javafx.css.converter.DurationConverter;
 import javafx.css.converter.EffectConverter;
 import javafx.css.converter.EnumConverter;
+import javafx.css.converter.FadeinColorConverter;
+import javafx.css.converter.FadeoutColorConverter;
 import javafx.css.converter.FontConverter;
 import javafx.css.converter.InsetsConverter;
 import javafx.css.converter.PaintConverter;
@@ -1409,6 +1411,10 @@ final public class CssParser {
             return innershadow(root);
         } else if ("dropshadow".regionMatches(true, 0, fcn, 0, 10)) {
             return dropshadow(root);
+        } else if ("fadein".regionMatches(true, 0, fcn, 0, 6)) {
+            return fadein(root);
+        } else if ("fadeout".regionMatches(true, 0, fcn, 0, 7)) {
+            return fadeout(root);
         } else if ("linear-gradient".regionMatches(true, 0, fcn, 0, 15)) {
             return parseLinearGradient(root);
         } else if ("radial-gradient".regionMatches(true, 0, fcn, 0, 15)) {
@@ -1554,6 +1560,53 @@ final public class CssParser {
             offsetYVal
         };
         return new ParsedValueImpl<ParsedValue[],Effect>(values, EffectConverter.DropShadowConverter.getInstance());
+    }
+
+    // fadein <color> <number>%
+    private ParsedValueImpl<ParsedValue[],Color> fadein(final Term root) throws ParseException {
+        // first term in the chain is the function name...
+        final String fn = (root.token != null) ? root.token.getText() : null;
+        if (fn == null || !"fadein".regionMatches(true, 0, fn, 0, 6)) {
+            final String msg = "Expected \'fadein\'";
+            error(root, msg);
+        }
+
+        Term arg = root;
+        if ((arg = arg.firstArg) == null) error(root, "Expected \'<color>\'");
+
+        final ParsedValueImpl<?,Color> color = parseColor(arg);
+
+        final Term prev = arg;
+        if ((arg = arg.nextArg) == null) error(prev, "Expected \'<percent\'");
+
+        final ParsedValueImpl<?,Size> opacity = parseSize(arg);
+
+        ParsedValueImpl[] values = new ParsedValueImpl[] { color, opacity };
+        return new ParsedValueImpl<ParsedValue[],Color>(values, FadeinColorConverter.getInstance());
+
+    }
+
+    // fadeout <color> <number>%
+    private ParsedValueImpl<ParsedValue[],Color> fadeout(final Term root) throws ParseException {
+        // first term in the chain is the function name...
+        final String fn = (root.token != null) ? root.token.getText() : null;
+        if (fn == null || !"fadeout".regionMatches(true, 0, fn, 0, 7)) {
+            final String msg = "Expected \'fadeout\'";
+            error(root, msg);
+        }
+
+        Term arg = root;
+        if ((arg = arg.firstArg) == null) error(root, "Expected \'<color>\'");
+
+        final ParsedValueImpl<?,Color> color = parseColor(arg);
+
+        final Term prev = arg;
+        if ((arg = arg.nextArg) == null) error(prev, "Expected \'<percent\'");
+
+        final ParsedValueImpl<?,Size> transparency = parseSize(arg);
+
+        ParsedValueImpl[] values = new ParsedValueImpl[] { color, transparency };
+        return new ParsedValueImpl<ParsedValue[],Color>(values, FadeoutColorConverter.getInstance());
     }
 
     // returns null if the Term is null or is not a cycle method.

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
@@ -32,6 +32,8 @@ import javafx.css.converter.DeriveSizeConverter;
 import javafx.css.converter.DurationConverter;
 import javafx.css.converter.EffectConverter;
 import javafx.css.converter.EnumConverter;
+import javafx.css.converter.FadeinColorConverter;
+import javafx.css.converter.FadeoutColorConverter;
 import javafx.css.converter.FontConverter;
 import javafx.css.converter.InsetsConverter;
 import javafx.css.converter.LadderConverter;
@@ -502,6 +504,14 @@ public class StyleConverter<F, T> {
         case "javafx.css.converter.DeriveSizeConverter":
         case "com.sun.javafx.css.parser.DeriveSizeConverter" :
             styleConverter = DeriveSizeConverter.getInstance();
+            break;
+        case "javafx.css.converter.FadeinColorConverter":
+        case "com.sun.javafx.css.parser.FadeinColorConverter":
+            styleConverter = FadeinColorConverter.getInstance();
+            break;
+        case "javafx.css.converter.FadeoutColorConverter":
+        case "com.sun.javafx.css.parser.FadeoutColorConverter":
+            styleConverter = FadeoutColorConverter.getInstance();
             break;
         case "javafx.css.converter.LadderConverter":
         case "com.sun.javafx.css.parser.LadderConverter" :

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/FadeinColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/FadeinColorConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.css.converter;
+
+import javafx.css.Size;
+import javafx.css.SizeUnits;
+import javafx.css.StyleConverter;
+import javafx.css.ParsedValue;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+/**
+ * Fade in (opacify) a Color from a Color and a opacity value.
+ *
+ * @since 12
+ */
+public final class FadeinColorConverter extends StyleConverter<ParsedValue[], Color> {
+
+    // lazy, thread-safe instantiation
+    private static class Holder {
+        static final FadeinColorConverter INSTANCE = new FadeinColorConverter();
+    }
+
+    public static FadeinColorConverter getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private FadeinColorConverter() {
+        super();
+    }
+
+    @Override
+    public Color convert(ParsedValue<ParsedValue[], Color> value, Font font) {
+        ParsedValue[] values = value.getValue();
+        final Color color = (Color) values[0].convert(font);
+        final Size opacity = (Size) values[1].convert(font);
+        return Color.rgb((int) (color.getRed() * 255), (int) (color.getGreen() * 255),
+                (int) (color.getBlue() * 255), opacity.pixels(font) == 1d ?
+                        1d : Math.min(1d, Math.round(color.getOpacity() * 255 * (1 + opacity.pixels(font))) / 255d));
+    }
+
+    @Override
+    public String toString() {
+        return "FadeinColorConverter";
+    }
+}

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/FadeoutColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/FadeoutColorConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.css.converter;
+
+import javafx.css.Size;
+import javafx.css.SizeUnits;
+import javafx.css.StyleConverter;
+import javafx.css.ParsedValue;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+/**
+ * Fade out (transparentize) a Color from a Color and a transparency value.
+ *
+ * @since 12
+ */
+public final class FadeoutColorConverter extends StyleConverter<ParsedValue[], Color> {
+
+    // lazy, thread-safe instantiation
+    private static class Holder {
+        static final FadeoutColorConverter INSTANCE = new FadeoutColorConverter();
+    }
+
+    public static FadeoutColorConverter getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private FadeoutColorConverter() {
+        super();
+    }
+
+    @Override
+    public Color convert(ParsedValue<ParsedValue[], Color> value, Font font) {
+        ParsedValue[] values = value.getValue();
+        final Color color = (Color) values[0].convert(font);
+        final Size transparency = (Size) values[1].convert(font);
+        return Color.rgb((int) (color.getRed() * 255), (int) (color.getGreen() * 255),
+                (int) (color.getBlue() * 255), transparency.pixels(font) == 0d ?
+                        0d : Math.round(color.getOpacity() * 255 * (1 - transparency.pixels(font))) / 255d);
+    }
+
+    @Override
+    public String toString() {
+        return "FadeoutColorConverter";
+    }
+}

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssParserTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssParserTest.java
@@ -214,6 +214,158 @@ public class CssParserTest {
 
     }
 
+    @Test
+    public void testFadein() {
+        // Properly fades in (makes more opaque) when given a positive percentage.
+        CssParser instance = new CssParser();
+        Stylesheet ss = instance.parse("* { -fx-background-color: fadein(rgba(35, 70, 112, 0.8), 10%); }");
+
+        assertNotNull(ss);
+        List<Rule> rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        List<Declaration> decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        Declaration decl = decls.get(0);
+        ParsedValue value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        Color paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0.88d, paint.getOpacity(), 0.01d);
+
+        // Properly fades out (makes less opaque) when given a negative percentage.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadein(rgba(35, 70, 112, 0.8), -10%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0.72d, paint.getOpacity(), 0.01d);
+
+        // Makes a color fully opaque when percentage is 100%.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadein(rgba(35, 70, 112, 0), 100%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(1d, paint.getOpacity(), 0.01d);
+
+        // Does not change the opacity when color is already fully opaque.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadein(rgba(35, 70, 112, 1), 5%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(1d, paint.getOpacity(), 0.01d);
+    }
+
+    @Test
+    public void testFadeout() {
+        // Properly fades out (makes less opaque) when given a positive percentage.
+        CssParser instance = new CssParser();
+        Stylesheet ss = instance.parse("* { -fx-background-color: fadeout(rgba(35, 70, 112, 0.8), 10%); }");
+
+        assertNotNull(ss);
+        List<Rule> rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        List<Declaration> decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+
+        Declaration decl = decls.get(0);
+        ParsedValue value = decl.getParsedValue();
+        assertTrue(value != null);
+        Color paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0.72d, paint.getOpacity(), 0.01d);
+
+        // Properly fades in (makes more opaque) when given a negative percentage.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadeout(rgba(35, 70, 112, 0.8), -10%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0.88d, paint.getOpacity(), 0.01d);
+
+        // Makes a color fully transparent when percentage is 100%.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadeout(rgba(35, 70, 112, 1), 100%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0d, paint.getOpacity(), 0.01d);
+
+        // Does not change the opacity when color is already fully transparent.
+        instance = new CssParser();
+        ss = instance.parse("* { -fx-background-color: fadeout(rgba(35, 70, 112, 0), 5%); }");
+        assertNotNull(ss);
+        rules = ss.getRules();
+        assertEquals(1, rules.size(), 0);
+        decls = RuleShim.getUnobservedDeclarationList(ss.getRules().get(0));
+        assertEquals(1, decls.size(), 0);
+        decl = decls.get(0);
+        value = decl.getParsedValue();
+        assertTrue(value != null);
+        assertTrue(((Paint[]) value.convert(null)).length == 1);
+        paint = (Color) ((Paint[]) value.convert(null))[0];
+        assertEquals(35 / 255d, paint.getRed(), 0.000001d);
+        assertEquals(70 / 255d, paint.getGreen(), 0.000001d);
+        assertEquals(112 / 255d, paint.getBlue(), 0.000001d);
+        assertEquals(0d, paint.getOpacity(), 0.01d);
+    }
+
     @Test public void testFontFace() {
 
         // http://fonts.googleapis.com/css?family=Bree+Serif


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8211038

```
fadein
fadein( <color> , <number>% )
```

The fadein function takes a color and computes a more opaque version of that color.
The second parameter is the opacity, ranging from 0% to 100%. Has no effect on
fully opaque colors.

Examples:

```
fadein(rgba(35, 70, 112, 0.8), 10%) => rgba(35, 70, 112, 0.88)
fadein(rgba(35, 70, 112, 0), 100%) => rgba(35, 70, 112) = rgb(35, 70, 112)

fadeout
fadeout( <color>, <number>% )
```

The fadeout functions takes a color and computes a more transparent version of that
color. The second parameter is the transparency, ranging from 0% to 100%. Has no effect
on fully transparent colors.

Examples:

```
fadeout(rgba(35, 70, 112, 0.8), 10%) => rgba(35, 70, 112, 0.72)
fadeout(rgba(35, 70, 122), 30%) => rgba(35, 70, 122, 0.7)
fadeout(rgb(35, 70, 112), 100%) => rgba(35, 70, 112, 0)
```