### PR TITLE
[WIP] test build to check whether we can download the JDK 11 GA build

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -4,7 +4,10 @@ set -uo pipefail
 echo "which java: $(which java)"
 ulimit -c unlimited -S
 
-sh ./gradlew all test -PCONF=DebugNative -x :web:test --no-daemon --stacktrace --info
+echo SKIPPING:  sh ./gradlew all test -PCONF=DebugNative -x :web:test --no-daemon --stacktrace --info
+
+java -version
+exit 0
 
 # Print core dumps when JVM crashes.
 RESULT=$?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ build_script:
       $client.DownloadFile($openJdk11, 'C:\Users\appveyor\openjdk11.zip')
       Expand-Archive -Path 'C:\Users\appveyor\openjdk11.zip' -DestinationPath 'C:\Users\appveyor\openjdk11'
       Copy-Item -Path 'C:\Users\appveyor\openjdk11\*\' -Destination 'C:\jdk11' -Recurse -Force
-      C:\Users\appveyor\openjdk11\bin\java -version
+      C:\Users\appveyor\openjdk11\jdk-11\bin\java -version
       echo "SKIPPING: .\tools\scripts\build.ps1"
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,71 +17,16 @@ build_script:
       $client.DownloadFile($openJdk11, 'C:\Users\appveyor\openjdk11.zip')
       Expand-Archive -Path 'C:\Users\appveyor\openjdk11.zip' -DestinationPath 'C:\Users\appveyor\openjdk11'
       Copy-Item -Path 'C:\Users\appveyor\openjdk11\*\' -Destination 'C:\jdk11' -Recurse -Force
-      . .\tools\scripts\build.ps1 2>&1
+      C:\Users\appveyor\openjdk11\bin\java -version
+      echo "SKIPPING: .\tools\scripts\build.ps1"
 
 on_finish:
   - ps: |
-        $dbgDir = ".\javafx-debug-symbols\"
-        $dbgArchive = "javafx-debug-symbols.zip"
-        if ((Get-ChildItem -Include @("*.pdb","*.map") -Recurse | Where { -not $_.PSIsContainer}).Count -gt 0) {
-          # The build generated at least one map or pdb file, so bundle them and upload to Appveyor.
-          Get-ChildItem -Include @("*.pdb","*.map") -Recurse | Copy-Item -Destination (New-Item -Type directory -Force $dbgDir) -Force
-          Compress-Archive -Path $($dbgDir + '*') -DestinationPath $dbgArchive -CompressionLevel Optimal
-          Push-AppveyorArtifact $dbgArchive -Verbose
-        }
-
-        $crashes = Get-ChildItem -Include hs_err_pid*.log -Recurse
-        $javaExe = $env:JAVA_HOME + '\bin'
-        ForEach ($crash in $crashes) {
-          $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\"
-          $env:Path += ";C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\"
-          $env:Path += ";C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x64\"
-          $env:Path += ";C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\"
-          Write-Host "Printing crash dump (${crash}):"
-          Get-Content $crash
-          $crashDump = $crash.DirectoryName + '\' + $crash.Basename + '.mdmp'
-          Write-Host "\n\n--- NATIVE BACK TRACE ---"
-          # https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/cdb-command-line-options
-          # !sym noisy = Activates noisy symbol loading.
-          # ~* = Thread status for all threads in the process.
-          # .kframes 100 = Set stack length to 100 frames.
-          # kP = Display stack backtrace with the full parameters for each function that is called in the stack trace.
-          # .ecxr = Display exception context record.
-          # dpp = Display referenced memory (32-bit or 64-bit depending on architecture) in DWORD or QWORD.
-          # r. = Displays the registers used in the current instruction.
-          # q = Quit.
-          cdb -v -z $crashDump -c '!sym noisy;~*;kP;dpp;r.;q' -i $javaExe -lines -y "srv*C:\MSSymbols*http://msdl.microsoft.com/download/symbols;$($env:APPVEYOR_BUILD_FOLDER)\javafx-debug-symbols\"
-          Write-Host "\n\n--- END NATIVE BACK TRACE ---"
-        }
-
-        # This technically works but is really inefficient as it requires an HTTP request for every
-        # single test. Ideally we want to batch the results. We can do this by POSTing to:
-        # $APPVEYOR_API_URL/api/tests/batch
-        # With JSON body:
-        # https://www.appveyor.com/docs/build-worker-api/#rest-3
-        # In order to do this we will need to iterate over all the XML files and convert them into
-        # a big JSON array.
-        Write-Host 'Uploading test results to AppVeyor…'
-        $wc = New-Object 'System.Net.WebClient'
-        $modules = @("javafx.base", "javafx.graphics", "javafx.controls", "javafx.fxml")
-        $ErrorActionPreference = "SilentlyContinue"
-        ForEach ($module in $modules) {
-          ForEach ($file in Get-ChildItem ".\modules\${module}\build\test-results\test\TEST-*.xml") {
-            try {
-              $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $file) 2>&1 | Out-Null
-            } catch [System.Net.WebException] {
-              # Ignore.
-            } finally {
-              $ErrorActionPreference = "Continue"
-            }
-          }
-        }
+      echo "on finish called"
 
 on_success:
   - ps: |
-        $modules = "javafx-modules.zip"
-        Compress-Archive -Path ".\build\modular-sdk" -DestinationPath $modules -CompressionLevel Optimal
-        Push-AppveyorArtifact $modules -Verbose
+      echo "on success called"
 
 cache:
   - C:\Users\appveyor\.gradle\caches


### PR DESCRIPTION
Test build...do not merge. I am testing that the logic to download the JDK 11 build from http://jdk.java.net/11/ still works after the GA release.