### PR TITLE
JDK-8188810: Fonts are blurry on Ubuntu 16.04 and Debian 9

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/freetype.c
+++ b/modules/javafx.graphics/src/main/native-font/freetype.c
@@ -389,21 +389,10 @@ JNIEXPORT void JNICALL OS_NATIVE(FT_1Set_1Transform)
     }
 }
 
-#define LIB_FREETYPE "libfreetype.so"
 JNIEXPORT jint JNICALL OS_NATIVE(FT_1Library_1SetLcdFilter)
     (JNIEnv *env, jclass that, jlong arg0, jint arg1)
 {
-//  return (jint)FT_Library_SetLcdFilter((FT_Library)arg0, (FT_LcdFilter)arg1);
-    static void *fp = NULL;
-    if (!fp) {
-        void* handle = dlopen(LIB_FREETYPE, RTLD_LAZY);
-        if (handle) fp = dlsym(handle, "FT_Library_SetLcdFilter");
-    }
-    jint rc = 0;
-    if (fp) {
-        rc = (jint)((jint (*)(jlong, jint))fp)(arg0, arg1);
-    }
-    return rc;
+    return (jint)FT_Library_SetLcdFilter((FT_Library)arg0, (FT_LcdFilter)arg1);
 }
 
 JNIEXPORT jint JNICALL OS_NATIVE(FT_1Done_1Face)


### PR DESCRIPTION
Reduce color fringes in FreeType subpixel rendering with a direct call
to the function FT_Library_SetLcdFilter, available since FreeType 2.3.0.
Note that the runtime reference to the shared library is the versioned
file name libfreetype.so.6.

Fixes javafxports/openjdk-jfx#229