### PR TITLE
Add IntelliJ IDEA related files to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ webrev/
 webrev.zip
 gradle.properties
 apps/samples/Ensemble8/lib/
+
+.idea/tasks.xml
+.idea/workspace.xml
+.idea/inspectionProfiles/*
+.idea/copyright/profiles_settings.xml
+.idea/codeStyles/*
+.idea/checkstyle-idea.xml


### PR DESCRIPTION
Makes working on OpenJFX with IntelliJ IDEA easier and less prone to
committing unnecessary files.