### PR TITLE
Adding back the flight recorder pulse logger

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
@@ -29,7 +29,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,12 +48,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * to ensure that the logging system works correctly.
  */
 class PrintLogger extends Logger {
-
-    /**
-     * A reference to the pulse logger. This will be null if pulse logging
-     * is not enabled.
-     */
-    private static PrintLogger printLogger;
 
     /**
      * A time in milliseconds which defines the threshold. If a pulse lasts <em>longer</em> than
@@ -110,7 +103,7 @@ class PrintLogger extends Logger {
 
     private Thread fxThread;
     private final ThreadLocal<ThreadLocalData> phaseData =
-        new ThreadLocal() {
+        new ThreadLocal<>() {
             @Override
             public ThreadLocalData initialValue() {
                 return new ThreadLocalData();
@@ -149,14 +142,12 @@ class PrintLogger extends Logger {
         active = new AtomicInteger(0);
     }
 
-    public static Logger getInstance() {
-        if (printLogger == null) {
-            boolean enabled = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.pulseLogger"));
-            if (enabled) {
-                printLogger = new PrintLogger();
-            }
+    public static Logger createInstance() {
+        boolean enabled = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.pulseLogger"));
+        if (enabled) {
+            return new PrintLogger();
         }
-        return printLogger;
+        return null;
     }
 
     /**
@@ -355,7 +346,7 @@ class PrintLogger extends Logger {
         int pulseCount;
         boolean pushedRender;
         StringBuffer message = new StringBuffer();
-        Map<String,Counter> counters = new ConcurrentHashMap();
+        Map<String,Counter> counters = new ConcurrentHashMap<>();
 
         void init(int n) {
             state = INCOMPLETE;
@@ -394,7 +385,7 @@ class PrintLogger extends Logger {
                 System.err.print(message);
                 if (!counters.isEmpty()) {
                     System.err.println("Counters:");
-                    List<Map.Entry<String,Counter>> entries = new ArrayList(counters.entrySet());
+                    List<Map.Entry<String,Counter>> entries = new ArrayList<>(counters.entrySet());
                     Collections.sort(entries, (a, b) -> a.getKey().compareTo(b.getKey()));
                     for (Map.Entry<String, Counter> entry : entries) {
                         System.err.println("\t" + entry.getKey() + ": " + entry.getValue().value);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PulseLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PulseLogger.java
@@ -31,33 +31,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PulseLogger {
-
     public static final boolean PULSE_LOGGING_ENABLED;
-
+    
+    private static final String [] DEFAULT_LOGGERS = {"com.sun.javafx.logging.PrintLogger", "com.sun.javafx.logging.jfr.JFRPulseLogger"};
     private static final Logger[] loggers;
 
     static {
-        List<Logger> list = new ArrayList();
-        Logger logger = PrintLogger.getInstance();
-        if (logger != null) {
-            list.add(logger);
+        List<Logger> list = new ArrayList<>();
+        for (String loggerClass : DEFAULT_LOGGERS) {
+            Logger logger = loadLogger(loggerClass);
+            if (logger != null) {
+                list.add(logger);
+            }
         }
-
-//        // Another optional logger could be added as follows:
-//        try {
-//            Class klass = Class.forName("com.sun.javafx.logging.OtherLogger");
-//            if (klass != null) {
-//                Method method = klass.getDeclaredMethod("getInstance");
-//                logger = (Logger) method.invoke(null);
-//                if (logger != null) {
-//                    list.add(logger);
-//                }
-//            }
-//        }
-//        catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-//            // Ignore
-//        }
-
         loggers = list.toArray(new Logger[list.size()]);
         PULSE_LOGGING_ENABLED = loggers.length > 0;
     }
@@ -108,5 +94,19 @@ public class PulseLogger {
         for (Logger logger: loggers) {
             logger.newInput(name);
         }
+    }
+    
+    // Loading known loggers reflectively, in case an expected module isn't available
+    private static Logger loadLogger(String className) {
+        try {
+            Class<?> klass = Class.forName(className);
+            if (klass != null) {
+                Method method = klass.getDeclaredMethod("createInstance");
+                return (Logger) method.invoke(null);
+            }
+        } catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            // Ignore
+        }
+        return null;
     }
 }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRInputEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRInputEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.logging.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+@Label("JavaFX Input")
+@Category("JavaFX")
+@Description("JavaFX input event")
+@StackTrace(false)
+@Enabled(false)
+public final class JFRInputEvent extends Event {
+    @Label("Input Type")
+    @Description("Input event type")
+    private String input;
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.logging.jfr;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+@Label("JavaFX Pulse Phase")
+@Category("JavaFX")
+@Description("Describes a phase in JavaFX pulse processing")
+@StackTrace(false)
+@Enabled(false)
+public final class JFRPulseEvent extends Event {
+    @PulseId
+    @Label("Pulse Id")
+    private int pulseId;
+
+    @Label("Phase Name")
+    private String phaseName;
+
+    public int getPulseId() {
+        return pulseId;
+    }
+
+    public void setPulseId(int pulseId) {
+        this.pulseId = pulseId;
+    }
+
+    public String getPhaseName() {
+        return phaseName;
+    }
+
+    public void setPhaseName(String phaseName) {
+        this.phaseName = phaseName;
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javafx.logging.jfr;
+
+import com.sun.javafx.logging.Logger;
+
+import jdk.jfr.FlightRecorder;
+
+public final class JFRPulseLogger extends Logger {
+    private final ThreadLocal<JFRPulseEvent> currentPulseEvent;
+    private final ThreadLocal<JFRInputEvent> currentInputEvent;
+
+    private int pulseNumber;
+    private int fxPulseNumber;
+    private int renderPulseNumber;
+    private Thread fxThread;
+
+    public static Logger createInstance() {
+        // Since events are off by default, and overhead is low, we can always
+        // have this pulse logger available.
+        return new JFRPulseLogger();
+    }
+
+    private JFRPulseLogger() {
+        FlightRecorder.register(JFRInputEvent.class);
+        FlightRecorder.register(JFRPulseEvent.class);
+        currentPulseEvent = new ThreadLocal<JFRPulseEvent>() {
+            @Override
+            public JFRPulseEvent initialValue() {
+                return new JFRPulseEvent();
+            }
+        };
+        currentInputEvent = new ThreadLocal<JFRInputEvent>() {
+            @Override
+            public JFRInputEvent initialValue() {
+                return new JFRInputEvent();
+            }
+        };
+    }
+
+    @Override
+    public void pulseStart() {
+        ++pulseNumber;
+        fxPulseNumber = pulseNumber;
+        if (fxThread == null) {
+            fxThread = Thread.currentThread();
+        }
+        newPhase("Pulse start");
+    }
+
+    @Override
+    public void pulseEnd() {
+        newPhase(null);
+        fxPulseNumber = 0;
+    }
+
+    @Override
+    public void renderStart() {
+        renderPulseNumber = fxPulseNumber;
+    }
+
+    @Override
+    public void renderEnd() {
+        newPhase(null);
+        renderPulseNumber = 0;
+    }
+
+    /**
+     * Finishes the current phase and starts a new one if phaseName is not null.
+     * 
+     * @param phaseName The name for the new phase.
+     */
+    @Override
+    public void newPhase(String phaseName) {
+        JFRPulseEvent event = currentPulseEvent.get();
+
+        /* Cleanup if no longer enabled */
+        if (!event.isEnabled()) {
+            event.setPhaseName(null);
+            return;
+        }
+
+        /* If there is an ongoing event, commit it */
+        if (event.getPhaseName() != null) {
+            event.commit();
+        }
+
+        /* Done if the new phase name is null */
+        if (phaseName == null) {
+            event.setPhaseName(null);
+            return;
+        }
+
+        event = new JFRPulseEvent();
+        event.begin();
+        event.setPhaseName(phaseName);
+        event.setPulseId(Thread.currentThread() == fxThread ? fxPulseNumber : renderPulseNumber);
+        currentPulseEvent.set(event);
+    }
+
+    @Override
+    public void newInput(String input) {
+        JFRInputEvent event = currentInputEvent.get();
+
+        /* Cleanup if no longer enabled */
+        if (!event.isEnabled()) {
+            event.setInput(null);
+            return;
+        }
+
+        /* If there is an ongoing event, commit it */
+        if (event.getInput() != null) {
+            event.commit();
+        }
+
+        /* Done if the new input is null */
+        if (input == null) {
+            event.setInput(null);
+            return;
+        }
+
+        event = new JFRInputEvent();
+        event.begin();
+        event.setInput(input);
+        currentInputEvent.set(event);
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/PulseId.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/PulseId.java
@@ -1,0 +1,26 @@
+package com.sun.javafx.logging.jfr;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jdk.jfr.Description;
+import jdk.jfr.Name;
+import jdk.jfr.Relational;
+
+/**
+ * This annotation defines a relation for future events that are related to the
+ * same pulse id. It also informs a user interface consuming events where a
+ * field contains a pulse id that the value could be useful to find other,
+ * related events.
+ */
+@Relational
+@Name("javafx.jfr.PulseId")
+@Retention(RUNTIME)
+@Target(FIELD)
+@Description("Binds events with same pulse id together")
+public @interface PulseId {
+
+}

--- a/modules/javafx.base/src/main/java/module-info.java
+++ b/modules/javafx.base/src/main/java/module-info.java
@@ -32,6 +32,7 @@
  */
 module javafx.base {
     requires java.desktop;
+    requires static jdk.jfr;
 
     exports javafx.beans;
     exports javafx.beans.binding;


### PR DESCRIPTION
1. Sorry about the formatting changes in the PrintLogger -  just habitually formatted the code after making the relevant changes.

2. These changes are not compatible with the attribute names in JDK 8. It is possible to make them compatible by renaming the fields, but in JDK 8 the attribute IDs and the attribute names differed. I think the current metadata is better going forward.

3. Because of 2, we would need to decide whether to drop backwards compatibility to Oracle JDK 8 in the JMC JavaFX plug-in or do some extra coding. Since the JavaFX events were dropped for some time (after 8?) and are just now re-introduced, I would suggest only supporting the new stuff in the next version of JMC.