### PR TITLE
JDK-8211304: [macOS] Crash on focus loss from dialog on macOS 10.14 Mojave

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -33,8 +33,7 @@
 #import "GlassStatics.h"
 
 
-// KCR: Temporarily enable VERBOSE logging (revert this when done debugging)
-#define VERBOSE
+//#define VERBOSE
 #ifndef VERBOSE
     #define LOG(MSG, ...)
 #else


### PR DESCRIPTION
This fixes [JDK-8211304](https://bugs.openjdk.java.net/browse/JDK-8211304). See that JBS bug for a reproducible test case. The following evaluation is copied from JBS:

This crash is caused by a latent bug in GlassTouches.m.

There are two related problems in glass' CGEventTapCallBack method, listenTouchEvents.

1) A CGEventTapCallBack method can receive two out of band values, kCGEventTapDisabledByTimeout and kCGEventTapDisabledByUserInput, and we are only handling the first of them.

2) We unconditionally call NSEvent::eventWithCGEvent without checking that the event in question is the right type, NSEventTypeGesture in our case.

The fix is to check for kCGEventTapDisabledByUserInput in addition to kCGEventTapDisabledByTimeout and re-enable the event tap when either out of band value occurs (a Google search shows that this is a common thing to do). This is necessary so that once we regain focus to the window we continue to get touch events.

In order to bullet-proof the code, I will also check for type == NSEventTypeGesture before calling NSEvent::eventWithCGEvent