### PR TITLE
Fix scrolling on mac [JDK-8183399]

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -425,8 +425,8 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     jdouble rotationY = 0.0;
     if (type == com_sun_glass_events_MouseEvent_WHEEL)
     {
-        rotationX = (jdouble)[theEvent deltaX];
-        rotationY = (jdouble)[theEvent deltaY];
+        rotationX = (jdouble)[theEvent scrollingDeltaX];
+        rotationY = (jdouble)[theEvent scrollingDeltaY];
 
         //XXX: check for equality for doubles???
         if (rotationX == 0.0 && rotationY == 0.0)


### PR DESCRIPTION
This fixes https://bugs.openjdk.java.net/browse/JDK-8183399 (https://github.com/javafxports/openjdk-jfx/issues/38)

The test program that prints the scrollEvent.getDeltaY() has now different values that keep decreasing: Old values:
```
-31.00006103515625
-28.000030517578125
-26.00006103515625
-24.000091552734375
-22.0001220703125
-20.0
-18.000030517578125
-16.00006103515625
-15.0
-14.000091552734375
-13.000030517578125
-12.0001220703125
-11.00006103515625
-9.000091552734375
-9.000091552734375
-8.000030517578125
-8.000030517578125
-7.0001220703125
-6.00006103515625
-6.00006103515625
-5.0
-5.0
-15.0
-12.0001220703125

```
Note the jump from -5 to -15 at the end.

New values:
```
140.0
130.0
120.0
110.0
100.0
90.0
80.0
80.0
70.0
70.0
60.0
60.0
50.0
50.0
50.0
40.0
40.0
40.0
30.0
30.0
30.0
20.0
20.0
20.0
20.0
20.0
10.0
10.0
10.0
10.0
10.0
10.0
10.0
10.0
```

Note that these values are higher in absolute value. I doubt this is a problem, as the delta's should only be used to give a relative indication?