### PR TITLE
JDK-8213619 Initialized additional environment variables.

### DIFF
--- a/tools/scripts/build.ps1
+++ b/tools/scripts/build.ps1
@@ -1,23 +1,38 @@
+.\gradlew --stop
 choco install ant
 choco install vswhere
 choco install zip
+choco install visualstudio2017community
+choco install visualstudio2017-workload-nativedesktop
+choco install windows-sdk-7.1
+choco install cygwin
+
+$cygwinPath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup").rootdir
+$env:Path += ";$($cygwinPath)\bin"
+
 $env:WINSDK_DIR = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots").KitsRoot10
-$env:VCINSTALLDIR = "$(vswhere -legacy -latest -property installationPath)\VC\Auxiliary\Build"
+$vsRoot = "$(vswhere -legacy -latest -property installationPath)"
+$env:VCINSTALLDIR = "$($vsRoot)\VC\Auxiliary\Build"
 $msvcToolsVer = Get-Content "$env:VCINSTALLDIR\Microsoft.VCToolsVersion.default.txt"
+$msvcRedistVer = Get-Content "$env:VCINSTALLDIR\Microsoft.VCRedistVersion.default.txt"
 if ([string]::IsNullOrWhitespace($msvcToolsVer)) {
   # The MSVC tools version file can have txt *or* props extension.
   $msvcToolsVer = Get-Content "$env:VCINSTALLDIR\Microsoft.VCToolsVersion.default.props"
 }
 $env:MSVC_VER = $msvcToolsVer
+$env:MSVC_REDIST_VER = $msvcRedistVer
+
+$files = Get-ChildItem "$($vsRoot)\VC\Redist\MSVC\$($msvcRedistVer)\x86\*.CRT\"
+$env:WINDOWS_CRT_VER = $files[0].Name.replace("Microsoft.VC","").replace(".CRT","")
+
 $env:VS150COMNTOOLS = $env:VCINSTALLDIR
 $env:VSVARS32FILE = "$env:VCINSTALLDIR\vcvars32.bat"
 refreshenv
 if ($env:APPVEYOR -eq "true") {
-  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=DebugNative --stacktrace -x :web:test --info --no-daemon
+  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug --stacktrace -x :web:test --info --no-daemon
   if ($lastexitcode -ne 0) {
     exit $lastexitcode
   }
 } else {
-  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=DebugNative --stacktrace -x :web:test --info
+  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug --stacktrace -x :web:test --info
 }
-

--- a/tools/scripts/build.ps1
+++ b/tools/scripts/build.ps1
@@ -2,13 +2,15 @@
 choco install ant
 choco install vswhere
 choco install zip
-choco install visualstudio2017community
-choco install visualstudio2017-workload-nativedesktop
-choco install windows-sdk-7.1
-choco install cygwin
+if ($env:APPVEYOR -ne "true") {
+  choco install visualstudio2017community
+  choco install visualstudio2017-workload-nativedesktop
+  choco install windows-sdk-7.1
+  choco install cygwin
 
-$cygwinPath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup").rootdir
-$env:Path += ";$($cygwinPath)\bin"
+  $cygwinPath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup").rootdir
+  $env:Path += ";$($cygwinPath)\bin"
+}
 
 $env:WINSDK_DIR = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots").KitsRoot10
 $vsRoot = "$(vswhere -legacy -latest -property installationPath)"
@@ -29,7 +31,7 @@ $env:VS150COMNTOOLS = $env:VCINSTALLDIR
 $env:VSVARS32FILE = "$env:VCINSTALLDIR\vcvars32.bat"
 refreshenv
 if ($env:APPVEYOR -eq "true") {
-  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug --stacktrace -x :web:test --info --no-daemon
+  .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=DebugNative --stacktrace -x :web:test --info --no-daemon
   if ($lastexitcode -ne 0) {
     exit $lastexitcode
   }


### PR DESCRIPTION
Added gradlew --stop so that the new environment variables get used by gradle. Added chocolatey install lines for the non-webkit dependencies mentioned in the windows build instructions.

Not all dlls were being added to the published artifacts if the machine's setup didn't match the defaults in win.gradle. For example vcruntime140.dll was not being included on my machine because MSVC_REDIST_VER was not set and WINDOWS_CRT_VER was not set, resulting in the win.gradle not finding vcruntime140.dll , and not including it. My WINDOWS_CRT_VER was 141 for example where the default was 150.

The only way I could find WINDOWS_CRT_VER was by looking at the folder names. There is probably a better way.

The last change was to change -PCONF=DebugNative to -PCONF=Debug. That's because with DebugNative, the prism dlls depend on the debug versions (vcruntime140d.dll for example), and those aren't packaged correctly in win.gradle in the DebugNative mode. I can remove this change, but I imagine this build script will be used as a starting point for developers, and it seems like it would be better to have a more general starting point that works reliably.