### PR TITLE
JDK-8211307: Add prefix to build tools paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -713,7 +713,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                 } else {
                     throw new GradleException("Unhandled package type for compile package ${pkgname}")
                 }
-                srcball.deleteOnExit();
+                srcball.delete();
             }
         } else {
             logger.quiet "all tool packages are present $packages"

--- a/build.gradle
+++ b/build.gradle
@@ -3200,7 +3200,7 @@ project(":web") {
                 exec {
                     workingDir("$webkitOutputDir")
                     def cmakeArgs = "-DENABLE_TOOLS=1"
-                    cmakeArgs = " $cmakeArgs -DCMAKE_C_COMPILER=${webkitProperties.compiler}"
+                    cmakeArgs = " $cmakeArgs -DCMAKE_C_COMPILER='${webkitProperties.compiler}'"
                     if (t.name == "win") {
                         // To enable ninja build on Windows
                         environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)

--- a/build.gradle
+++ b/build.gradle
@@ -396,6 +396,10 @@ ext.IS_COMPILE_HARFBUZZ = Boolean.parseBoolean(COMPILE_HARFBUZZ)
 defineProperty("COMPILE_PARFAIT", "false")
 ext.IS_COMPILE_PARFAIT = Boolean.parseBoolean(COMPILE_PARFAIT)
 
+// BUILD_TOOLS_DOWNLOAD_SCRIPT specifies a path of a gradle script which downloads
+// required build tools.
+defineProperty("BUILD_TOOLS_DOWNLOAD_SCRIPT", "")
+
 // Define the SWT.jar that we are going to have to download during the build process based
 // on what platform we are compiling from (not based on our target).
 ext.SWT_FILE_NAME = IS_MAC ? "org.eclipse.swt.cocoa.macosx.x86_64_3.105.3.v20170228-0512" :
@@ -687,7 +691,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                 def String basename = pkgname.substring(0,pkgname.lastIndexOf("."))
                 def File pkgdir = file("$destdir/$basename")
 
-                if (pkgname.endsWith(".tgz")) {
+                if (pkgname.endsWith(".tgz") || pkgname.endsWith("tar.gz")) {
                     if (IS_LINUX || IS_MAC) {
                         // use native tar to support symlinks
                         pkgdir.mkdirs()
@@ -759,7 +763,8 @@ void ant(String conf,   // platform configuration
                     "INCLUDE"              : WINDOWS_VS_INCLUDE,
                     "LIB"                  : WINDOWS_VS_LIB,
                     "LIBPATH"              : WINDOWS_VS_LIBPATH,
-                    "DXSDK_DIR"            : WINDOWS_DXSDK_DIR
+                    "DXSDK_DIR"            : WINDOWS_DXSDK_DIR,
+                    "PATH"                 : WINDOWS_VS_PATH
             ]);
             commandLine "cmd", "/c", ant, "-Dbuild.compiler=javac1.7"
         } else {
@@ -1078,6 +1083,11 @@ void commonModuleSetup(Project p, List<String> moduleChain) {
             }
         }
     }
+}
+
+if (BUILD_TOOLS_DOWNLOAD_SCRIPT != "") {
+    println "Include build tools download script:${BUILD_TOOLS_DOWNLOAD_SCRIPT}"
+    apply from: BUILD_TOOLS_DOWNLOAD_SCRIPT
 }
 
 // Now we need to define the native compilation tasks. The set of parameters to
@@ -3190,26 +3200,14 @@ project(":web") {
                 exec {
                     workingDir("$webkitOutputDir")
                     def cmakeArgs = "-DENABLE_TOOLS=1"
+                    cmakeArgs = " $cmakeArgs -DCMAKE_C_COMPILER=${webkitProperties.compiler}"
                     if (t.name == "win") {
-                        String parfaitPath = IS_COMPILE_PARFAIT ? System.getenv().get("PARFAIT_PATH") + ";" : "";
-                        Map environmentSettings = new HashMap(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
-                        environmentSettings["PATH"] = parfaitPath + "$WINDOWS_VS_PATH"
-                        /* To build with ICU:
-                        1. Download http://javaweb.us.oracle.com/jcg/fx-webrevs/RT-17164/WebKitLibrariesICU.zip
-                        and unzip it to WebKitLibraries folder.
-                        2. Copy DLLs from
-                        WebKitLibrariesICU.zip\WebKitLibraries\import\runtime
-                        to %windir%\system32
-                        3. Uncomment the line below
-                         */
-                        // args("--icu-unicode")
-
                         // To enable ninja build on Windows
-                        environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT + ['CC' : 'cl', 'CXX' : 'cl'])
+                        environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                     } else if (t.name == "mac") {
-                        cmakeArgs = "-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_MIN_VERSION -DCMAKE_OSX_SYSROOT=$MACOSX_SDK_PATH"
+                        cmakeArgs = " $cmakeArgs -DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_MIN_VERSION -DCMAKE_OSX_SYSROOT=$MACOSX_SDK_PATH"
                     } else if (t.name == "linux") {
-                        cmakeArgs = "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_C_COMPILER=${webkitProperties.compiler}"
+                        cmakeArgs = " $cmakeArgs -DCMAKE_SYSTEM_NAME=Linux"
                         if (IS_64) {
                             cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
                         } else {
@@ -3230,7 +3228,12 @@ project(":web") {
                         environment([
                             "COMPILE_PARFAIT" : "true"
                         ])
+                        environment "PATH", System.env.PARFAIT_PATH + File.pathSeparator + environment.PATH
                         cmakeArgs = "-DCMAKE_C_COMPILER=parfait-gcc -DCMAKE_CXX_COMPILER=parfait-g++"
+                    }
+
+                    if (project.hasProperty('toolsPath')) {
+                        environment "PATH", toolsPath + File.pathSeparator + environment.PATH
                     }
 
                     environment([

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -62,6 +62,13 @@ if (IS_DEBUG_NATIVE) {
     linkFlags += "-g"
 }
 
+def toolchainDir
+if (hasProperty('toolchainDir')) {
+    toolchainDir = ext.toolchainDir + "/"
+} else {
+    toolchainDir = ""
+}
+
 def gtk2CCFlags = [  ];
 def gtk3CCFlags = [ "-Wno-deprecated-declarations" ];
 def gtk2LinkFlags = [ ];
@@ -73,14 +80,14 @@ setupTools("linux_gtk2",
     { propFile ->
         ByteArrayOutputStream results1 = new ByteArrayOutputStream();
         exec {
-            commandLine("pkg-config", "--cflags", "gtk+-2.0", "gthread-2.0", "xtst")
+            commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-2.0", "gthread-2.0", "xtst")
             setStandardOutput(results1);
         }
         propFile << "cflagsGTK2=" << results1.toString().trim() << "\n";
 
         ByteArrayOutputStream results3 = new ByteArrayOutputStream();
         exec {
-            commandLine("pkg-config", "--libs", "gtk+-2.0", "gthread-2.0", "xtst")
+            commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-2.0", "gthread-2.0", "xtst")
             setStandardOutput(results3);
         }
         propFile << "libsGTK2=" << results3.toString().trim()  << "\n";
@@ -101,7 +108,7 @@ setupTools("linux_gtk3",
     { propFile ->
         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
         exec {
-            commandLine("pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst")
+            commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst")
             setStandardOutput(results2);
             ignoreExitValue(true)
         }
@@ -109,7 +116,7 @@ setupTools("linux_gtk3",
 
         ByteArrayOutputStream results4 = new ByteArrayOutputStream();
         exec {
-            commandLine("pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst")
+            commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst")
             setStandardOutput(results4);
             ignoreExitValue(true)
         }
@@ -135,14 +142,14 @@ setupTools("linux_pango_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
         exec {
-            commandLine "pkg-config", "--cflags", "pangoft2"
+            commandLine "${toolchainDir}pkg-config", "--cflags", "pangoft2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
         exec {
-            commandLine "pkg-config", "--libs", "pangoft2"
+            commandLine "${toolchainDir}pkg-config", "--libs", "pangoft2"
             standardOutput = results
         }
         propFile << "libs=" << results.toString().trim();
@@ -166,14 +173,14 @@ setupTools("linux_freetype_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
         exec {
-            commandLine "pkg-config", "--cflags", "freetype2"
+            commandLine "${toolchainDir}pkg-config", "--cflags", "freetype2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
         exec {
-            commandLine "pkg-config", "--libs", "freetype2"
+            commandLine "${toolchainDir}pkg-config", "--libs", "freetype2"
             standardOutput = results
         }
         propFile << "libs=" << results.toString().trim();
@@ -190,8 +197,8 @@ setupTools("linux_freetype_tools",
     }
 )
 
-def compiler = IS_COMPILE_PARFAIT ? "parfait-gcc" : "gcc";
-def linker = IS_COMPILE_PARFAIT ? "parfait-g++" : "g++";
+def compiler = IS_COMPILE_PARFAIT ? "parfait-gcc" : "${toolchainDir}gcc";
+def linker = IS_COMPILE_PARFAIT ? "parfait-g++" : "${toolchainDir}g++";
 
 LINUX.glass = [:]
 LINUX.glass.variants = ["glass", "glassgtk2"]
@@ -307,7 +314,7 @@ LINUX.fontPango.lib = "javafx_font_pango"
 LINUX.media = [:]
 LINUX.media.compiler = compiler
 LINUX.media.linker = linker
-LINUX.media.ar = "ar"
+LINUX.media.ar = "${toolchainDir}ar"
 
 LINUX.webkit = [:]
 LINUX.webkit.compiler = compiler

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,9 @@ defineProperty("MACOSX_MIN_VERSION", "10.10");
 setupTools("mac_tools",
     { propFile ->
         propFile << ""
-        if (!file(defaultSdkPath).isDirectory()) {
+        if (project.hasProperty('setupMacTools')) {
+            setupMacTools(propFile)
+        } else if (!file(defaultSdkPath).isDirectory()) {
             // Get list of all macosx sdks
             ByteArrayOutputStream results = new ByteArrayOutputStream();
             exec {
@@ -126,9 +128,15 @@ def linkFlags = [
         "-framework", "Security",
         "-dynamiclib", "-lobjc"].flatten();
 
+def toolchainDir
+if (hasProperty('toolchainDir')) {
+    toolchainDir = ext.toolchainDir + "/"
+} else {
+    toolchainDir = ""
+}
 
-def compiler = IS_COMPILE_PARFAIT ? "parfait-clang" : "clang";
-def linker = IS_COMPILE_PARFAIT ? "parfait-clang++" : "clang++";
+def compiler = IS_COMPILE_PARFAIT ? "parfait-clang" : "${toolchainDir}clang";
+def linker = IS_COMPILE_PARFAIT ? "parfait-clang++" : "${toolchainDir}clang++";
 
 MAC.glass = [:]
 MAC.glass.javahInclude = [
@@ -208,4 +216,8 @@ MAC.media.compiler = "${compiler} ${ccBaseFlags.join(" ")}"
 //MAC.media.ccFlags = ccBaseFlags
 MAC.media.linker = "${linker} ${commonParams.join(" ")}"
 //MAC.media.linkFlags = commonParams
-MAC.media.ar = "libtool"
+MAC.media.ar = "${toolchainDir}libtool"
+
+MAC.webkit = [:]
+MAC.webkit.compiler = compiler
+MAC.webkit.linker = linker

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -41,26 +41,30 @@ WIN.modLibDest = "lib"
 
 setupTools("windows_tools",
     { propFile ->
-        // Create the properties file
-        ByteArrayOutputStream results = new ByteArrayOutputStream();
-        String winsdkDir = System.getenv().get("WINSDK_DIR");
-        exec({
-            environment([
-                    "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
-                    "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
-                    "VCARCH"     : IS_64 ? "amd64" : "x86",
-                    "SDKARCH"    : IS_64 ? "/x64" : "/x86",
-            ]);
-            commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
-            setStandardOutput(results);
-        });
-        BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
-        reader.readLine();
-        reader.readLine();
-        String line;
-        while ((line = reader.readLine()) != null && !line.startsWith("######")) {
-            line = line.replace("\\", "/").replace("/@@ENDOFLINE@@", "").replace("@@ENDOFLINE@@", "").replace("//", "/").replace("windows.vs.", "WINDOWS_VS_");
-            propFile << line << "\r\n";
+        if (project.hasProperty('setupWinTools')) {
+            setupWinTools(propFile)
+        } else {
+            // Create the properties file
+            ByteArrayOutputStream results = new ByteArrayOutputStream();
+            String winsdkDir = System.getenv().get("WINSDK_DIR");
+            exec({
+                environment([
+                        "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
+                        "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
+                        "VCARCH"     : IS_64 ? "amd64" : "x86",
+                        "SDKARCH"    : IS_64 ? "/x64" : "/x86",
+                ]);
+                commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
+                setStandardOutput(results);
+            });
+            BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
+            reader.readLine();
+            reader.readLine();
+            String line;
+            while ((line = reader.readLine()) != null && !line.startsWith("######")) {
+                line = line.replace("\\", "/").replace("/@@ENDOFLINE@@", "").replace("@@ENDOFLINE@@", "").replace("//", "/").replace("windows.vs.", "WINDOWS_VS_");
+                propFile << line << "\r\n";
+            }
         }
     },
     { properties ->
@@ -133,7 +137,9 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
 ];
 def msvcVer = System.getenv("MSVC_VER") ?: "14.10.25017"
 def msvcBinDir = ""
-if (winVsVer == 150) {
+if (hasProperty('toolchainDir')) {
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/${IS_64 ? 'x64' : 'x86'}"
+} else if (winVsVer == 150) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/HostX64/x64"
                       : "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/HostX86/x86")
@@ -155,7 +161,6 @@ if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
         winSdkBinDir += "/" + (IS_64 ? "x64" : "x86")
     }
 }
-println "winSdkBinDir=$winSdkBinDir"
 
 ext.RC = cygpath("$winSdkBinDir/rc.exe")
 def rcCompiler = RC
@@ -427,6 +432,8 @@ WIN.media.linker = IS_COMPILE_PARFAIT ? "${parfaitPath}/parfait-link.exe" : "lin
 WIN.media.ar = IS_COMPILE_PARFAIT ? "${parfaitPath}/parfait-lib.exe" : "lib.exe";
 
 WIN.webkit = [:]
+WIN.webkit.compiler = compiler
+WIN.webkit.linker = linker
 WIN.webkit.rcCompiler = rcCompiler
 WIN.webkit.rcSource = defaultRcSource
 WIN.webkit.rcFlags = ["/d", "JFX_FNAME=jfxwebkit.dll", "/d", "JFX_INTERNAL_NAME=webkit", rcFlags].flatten();

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -39,6 +39,8 @@ WIN.library = { name -> return "${name}.dll" as String }
 WIN.libDest = "bin"
 WIN.modLibDest = "lib"
 
+def CPU_BITS = IS_64 ? "x64" : "x86"
+
 setupTools("windows_tools",
     { propFile ->
         if (project.hasProperty('setupWinTools')) {
@@ -79,6 +81,7 @@ setupTools("windows_tools",
         defineProperty("WINDOWS_DXSDK_DIR", properties, System.getenv().get("DXSDK_DIR"))
         defineProperty("WINDOWS_VS_INCLUDE", properties, "$WINDOWS_VS_VCINSTALLDIR/INCLUDE;" + "$WINDOWS_SDK_DIR/include;")
         defineProperty("WINDOWS_VS_VER", properties, "150")
+        defineProperty("WINDOWS_CRT_VER", properties, "150")
         defineProperty("WINDOWS_VS_LIB", properties, "$WINDOWS_VS_VCINSTALLDIR/LIB;" + "$WINDOWS_SDK_DIR/lib;")
         defineProperty("WINDOWS_VS_LIBPATH", properties, "$WINDOWS_VS_VCINSTALLDIR/LIB;")
         def parfaitPath = IS_COMPILE_PARFAIT ? System.getenv().get("PARFAIT_PATH") + ";" : "";
@@ -138,11 +141,9 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
 def msvcVer = System.getenv("MSVC_VER") ?: "14.10.25017"
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
-    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/${IS_64 ? 'x64' : 'x86'}"
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$CPU_BITS"
 } else if (winVsVer == 150) {
-    msvcBinDir = (IS_64
-                      ? "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/HostX64/x64"
-                      : "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/HostX86/x86")
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/Host${CPU_BITS}/$CPU_BITS"
 } else if (winVsVer <= 120) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
@@ -152,13 +153,13 @@ def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
 def linker = IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe")
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
 if (WINDOWS_VS_VER != "100") {
-    winSdkBinDir += "/" + (IS_64 ? "x64" : "x86")
+    winSdkBinDir += "/$CPU_BITS"
 }
 
 if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
     winSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION"
     if (WINDOWS_VS_VER != "100") {
-        winSdkBinDir += "/" + (IS_64 ? "x64" : "x86")
+        winSdkBinDir += "/$CPU_BITS"
     }
 }
 
@@ -178,20 +179,21 @@ ext.MC = cygpath("$winSdkBinDir/mt.exe")
 if (!file(RC).exists()) throw new GradleException("FAIL: cannot find RC: " + RC)
 if (!file(FXC).exists()) throw new GradleException("FAIL: cannot find FXC: " + FXC)
 
-def msvcRedistVer = System.getenv("MSVC_REDIST_VER") ?: "14.10.25008"
-String msvcRedstDir = (IS_64
-                  ? "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/x64"
-                  : "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/x86")
+def msvcRedstDir
+if (hasProperty('toolchainDir')) {
+    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$CPU_BITS"
+} else {
+    def msvcRedistVer = System.getenv("MSVC_REDIST_VER") ?: "14.10.25008"
+    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CPU_BITS"
+}
 
-String winSdkDllDir = (IS_64
-                  ? "$WINDOWS_VS_WINSDKDLLINSTALLDIR/x64"
-                  : "$WINDOWS_VS_WINSDKDLLINSTALLDIR/x86")
+def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CPU_BITS"
 
 def WINDOWS_DLL_VER = WINDOWS_VS_VER
 ext.MSVCR = null
 ext.MSVCP = null
 
-def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: "150"
+def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: WINDOWS_CRT_VER
 if (WINDOWS_VS_VER == "150") {
     WINDOWS_DLL_VER = "140"
     ext.MSVCR = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT/vcruntime${WINDOWS_DLL_VER}.dll")

--- a/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
@@ -45,7 +45,7 @@ elseif (APPLE)
         platform/cf/CFURLExtras.cpp
     )
 # find_library(OPENGL_LIBRARY OpenGL)
-    find_library(ACCELERATE_LIBRARY accelerate)
+    find_library(ACCELERATE_LIBRARY Accelerate)
     list(APPEND WebCore_LIBRARIES
         ${ACCELERATE_LIBRARY}
         # ${OPENGL_LIBRARY}

--- a/modules/javafx.web/src/main/native/Source/WebCore/WebCoreMacros.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/WebCoreMacros.cmake
@@ -64,6 +64,7 @@ function(GENERATE_BINDINGS target)
     set(binding_generator ${WEBCORE_DIR}/bindings/scripts/generate-bindings-all.pl)
     set(idl_attributes_file ${WEBCORE_DIR}/bindings/scripts/IDLAttributes.json)
     set(idl_files_list ${CMAKE_CURRENT_BINARY_DIR}/idl_files_${target}.tmp)
+    set(idl_include_list ${CMAKE_CURRENT_BINARY_DIR}/idl_include_${target}.tmp)
     set(_supplemental_dependency)
 
     set(content)
@@ -80,6 +81,7 @@ function(GENERATE_BINDINGS target)
         --generator ${arg_GENERATOR}
         --outputDir ${arg_DESTINATION}
         --idlFilesList ${idl_files_list}
+        --includeDirsList ${idl_include_list}
         --preprocessor "${CODE_GENERATOR_PREPROCESSOR}"
         --idlAttributesFile ${idl_attributes_file}
     )
@@ -90,13 +92,17 @@ function(GENERATE_BINDINGS target)
     if (PROCESSOR_COUNT)
         list(APPEND args --numOfJobs ${PROCESSOR_COUNT})
     endif ()
+    set(include_dir)
     foreach (i IN LISTS arg_IDL_INCLUDES)
         if (IS_ABSOLUTE ${i})
-            list(APPEND args --include ${i})
+            set(f ${i})
         else ()
-            list(APPEND args --include ${CMAKE_CURRENT_SOURCE_DIR}/${i})
+            set(f ${CMAKE_CURRENT_SOURCE_DIR}/${i})
         endif ()
+        set(include_dir "${include_dir}${f}\n")
     endforeach ()
+    file(WRITE ${idl_include_list} ${include_dir})
+
     foreach (i IN LISTS arg_PP_EXTRA_OUTPUT)
         list(APPEND args --ppExtraOutput ${i})
     endforeach ()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/generate-bindings-all.pl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/generate-bindings-all.pl
@@ -48,8 +48,9 @@ my @ppExtraArgs;
 my $numOfJobs = 1;
 my $idlAttributesFile;
 my $showProgress;
+my $includeDirsList;
 
-GetOptions('include=s@' => \@idlDirectories,
+GetOptions('includeDirsList=s' => \$includeDirsList,
            'outputDir=s' => \$outputDirectory,
            'idlFilesList=s' => \$idlFilesList,
            'generator=s' => \$generator,
@@ -68,6 +69,10 @@ my @idlFiles;
 open(my $fh, '<', $idlFilesList) or die "Cannot open $idlFilesList";
 @idlFiles = map { (my $path = $_) =~ s/\r?\n?$//; CygwinPathIfNeeded($path) } <$fh>;
 close($fh) or die;
+
+open(my $dh, '<', $includeDirsList) or die "Cannot open $includeDirsList";
+@idlDirectories = map { (my $path = $_) =~ s/\r?\n?$//; CygwinPathIfNeeded($path) } <$dh>;
+close($dh) or die;
 
 my %oldSupplements;
 my %newSupplements;
@@ -94,7 +99,7 @@ my @args = (File::Spec->catfile($scriptDir, 'generate-bindings.pl'),
             '--preprocessor', $preprocessor,
             '--idlAttributesFile', $idlAttributesFile,
             '--write-dependencies');
-push @args, map { ('--include', $_) } @idlDirectories;
+push @args, map { ('--includeDirsList', $_) } $includeDirsList;
 push @args, '--supplementalDependencyFile', $supplementalDependencyFile if $supplementalDependencyFile;
 
 my %directoryCache;

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/generate-bindings.pl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/generate-bindings.pl
@@ -57,8 +57,9 @@ my $verbose;
 my $supplementalDependencyFile;
 my $additionalIdlFiles;
 my $idlAttributesFile;
+my $includeDirsList;
 
-GetOptions('include=s@' => \@idlDirectories,
+GetOptions('includeDirsList=s' => \$includeDirsList,
            'outputDir=s' => \$outputDirectory,
            'outputHeadersDir=s' => \$outputHeadersDirectory,
            'generator=s' => \$generator,
@@ -71,6 +72,10 @@ GetOptions('include=s@' => \@idlDirectories,
            'supplementalDependencyFile=s' => \$supplementalDependencyFile,
            'additionalIdlFiles=s' => \$additionalIdlFiles,
            'idlAttributesFile=s' => \$idlAttributesFile);
+
+open(my $dh, '<', $includeDirsList) or die "Cannot open $includeDirsList";
+@idlDirectories = map { (my $path = $_) =~ s/\r?\n?$//; CygwinPathIfNeeded($path) } <$dh>;
+close($dh) or die;
 
 die('Must specify input file.') unless @ARGV;
 die('Must specify generator') unless defined($generator);
@@ -262,4 +267,11 @@ sub generateEmptyHeaderAndCpp
     open FH, "> ${outputDirectory}/${cppName}" or die "Cannot open $cppName\n";
     print FH $contents;
     close FH;
+}
+
+sub CygwinPathIfNeeded
+{
+    my $path = shift;
+    return Cygwin::win_to_posix_path($path) if ($^O eq 'cygwin');
+    return $path;
 }

--- a/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
+++ b/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
@@ -2173,9 +2173,10 @@ sub generateBuildSystemFromCMakeProject
     } elsif (isJava() && isAnyWindows()) {
         push @args, "-G";
         if (isWin64()) {
-            push @args, "'Visual Studio 15 2017 Win64'";
+            push @args, '"Visual Studio 15 2017 Win64"';
+            push @args, '-DCMAKE_GENERATOR_TOOLSET="host=x64"';
         } else {
-            push @args, "'Visual Studio 15 2017'";
+            push @args, '"Visual Studio 15 2017"';
         }
     } elsif (isAnyWindows() && isWin64()) {
         push @args, '-G "Visual Studio 15 2017 Win64"';


### PR DESCRIPTION
Currently JavaFX uses build tools{MSVC, GCC, Clang, CMake,..etc} from standard system paths. Adding prefix to each of those tools would help to have a custom build tools without disturbing standard tools.

This fix provides a new gradle property named BUILD_TOOLS_DOWNLOAD_SCRIPT, which could be used to point to a supplement gradle file which can have the logic to setup the custom toolchain.

In additional to provisioning toolchain prefix, this patch also has changes to javafx.web module to workaround "command line is too long" issue on windows when custom toolchain path length is long.