### PR TITLE
JDK-8214069 : (JavaFX) Default to xdg-open for document opening on UNIX

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
@@ -28,7 +28,6 @@ package com.sun.javafx.application;
 import java.awt.Desktop;
 import java.io.File;
 import java.net.URI;
-
 import javafx.application.Application;
 
 public abstract class HostServicesDelegate {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
@@ -28,6 +28,7 @@ package com.sun.javafx.application;
 import java.awt.Desktop;
 import java.io.File;
 import java.net.URI;
+
 import javafx.application.Application;
 
 public abstract class HostServicesDelegate {
@@ -122,8 +123,14 @@ public abstract class HostServicesDelegate {
             return toURIString(System.getProperty("user.dir"));
         }
 
-        static final String[] browsers = {"google-chrome", "firefox", "opera",
-            "konqueror", "mozilla"};
+        static final String[] browsers = {
+                "xdg-open",
+                "google-chrome",
+                "firefox",
+                "opera",
+                "konqueror",
+                "mozilla"
+        };
 
         @Override
         public void showDocument(final String uri) {


### PR DESCRIPTION
As per #260, here is a PR to default to `xdg-open` for document opening on UNIX systems.
It keeps the previous method as fallback in case of failure.

Little implementation note : chose to use try-catch rather than calling `which xdg-open` as this catches the nonexistence of `xdg-open` (never seen that for myself though) and also failure of `xdg-open` itself (in whatever case this might happen).

The only backwards compatibility lost here is if the users/developers were (un)knowingly relying on the lookup order of the browsers and not expecting the default browser to be used (imagining they have multiple browsers installed). I reckon this is acceptable.

---

As a side-note, while there are no tests relating to that part of the code, I still got test failures relating to prism/gtk.
Would be an interesting topic to investigate given #287 maybe ? (although these warnings don't look like they would be related as they're mostly type casting issues)
```
> Task :graphics:nativeFontFreetype
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-font/pango.c: In function ‘Java_com_sun_javafx_font_freetype_OSPango_FcConfigAppFontAddFile’:
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-font/pango.c:228:73: warning: passing argument 1 of ‘(jboolean (*)(void *, const char *))fp’ makes pointer from integer without a cast [-Wint-conversion]
                 rc = (jboolean)((jboolean (*)(void *, const char *))fp)(arg0, text);
                                                                         ^~~~
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-font/pango.c:228:73: note: expected ‘void *’ but argument is of type ‘jlong’ {aka ‘long int’}
> Task :graphics:ccLinuxFontPango
> Task :graphics:linkLinuxFontPango
> Task :graphics:nativeFontPango
> Task :graphics:ccLinuxGlassGlass
> Task :graphics:linkLinuxGlassGlass
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp: In member function ‘virtual void WindowContextBase::enableOrResetIME()’:
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp:236:66: error: cast between incompatible function types from ‘int (*)(XIM, XPointer, XPointer)’ {aka ‘int (*)(_XIM*, char*, char*)’} to ‘XIMProc’ {aka ‘void (*)(_XIM*, char*, char*)’} [-Werror=cast-function-type]
         XIMCallback startCallback = {(XPointer) jview, (XIMProc) im_preedit_start};
                                                                  ^~~~~~~~~~~~~~~~
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp: In function ‘void process_dnd_source_mouse_release(GdkWindow*, GdkEventButton*)’:
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp:827:44: error: cast between incompatible function types from ‘gboolean (*)()’ {aka ‘int (*)()’} to ‘GSourceFunc’ {aka ‘int (*)(void*)’} [-Werror=cast-function-type]
         gdk_threads_add_idle((GSourceFunc) dnd_finish_callback, NULL);
                                            ^~~~~~~~~~~~~~~~~~~
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp: In function ‘void process_dnd_source_drop_finished(GdkWindow*, GdkEventDND*)’:
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp:939:40: error: cast between incompatible function types from ‘gboolean (*)()’ {aka ‘int (*)()’} to ‘GSourceFunc’ {aka ‘int (*)(void*)’} [-Werror=cast-function-type]
     gdk_threads_add_idle((GSourceFunc) dnd_finish_callback, NULL);
                                        ^~~~~~~~~~~~~~~~~~~
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp: In static member function ‘static GdkPixbuf* DragView::get_drag_image(gboolean*, gint*, gint*)’:
/home/tristan/perso/openjdk-jfx/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp:1116:71: error: cast between incompatible function types from ‘void (*)(gpointer)’ {aka ‘void (*)(void*)’} to ‘GdkPixbufDestroyNotify’ {aka ‘void (*)(unsigned char*, void*)’} [-Werror=cast-function-type]
                                 w, h, w * 4, (GdkPixbufDestroyNotify) g_free, NULL);
                                                                       ^~~~~~
cc1plus: all warnings being treated as errors
cc1plus: all warnings being treated as errors
> Task :graphics:ccLinuxGlassGlassgtk2 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':graphics:ccLinuxGlassGlassgtk2'.
> java.util.concurrent.ExecutionException: org.gradle.process.internal.ExecException: Process 'command 'gcc'' finished with non-zero exit value 1


```