### PR TITLE
Improvements in javafx cache for native files (JDK-8214397)

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -240,7 +240,8 @@ public class NativeLibLoader {
             }
         }
         if (!cacheDirOk) {
-            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx/cache/" + jfxVersion;
+            String username = System.getProperty("user.name", "anonymous");
+            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx/"+username+"/cache/" + jfxVersion;
             cacheDir = new File(tmpCache);
             if (cacheDir.exists()) {
                 if (!cacheDir.isDirectory()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -222,15 +222,34 @@ public class NativeLibLoader {
 
     private static String cacheLibrary(InputStream is, String name, Class caller) throws IOException {
         String jfxVersion = System.getProperty("javafx.version", "versionless");
-        String userCache = System.getProperty("user.home") + "/.openjfx/cache/" + jfxVersion;
+        String userCache = System.getProperty("javafx.cachedir", "");
+        if (userCache.isEmpty()) {
+            userCache = System.getProperty("user.home") + "/.openjfx/cache/" + jfxVersion;
+        }
         File cacheDir = new File(userCache);
+        boolean cacheDirOk = true;
         if (cacheDir.exists()) {
             if (!cacheDir.isDirectory()) {
-                throw new IOException ("Cache exists but is not a directory: "+cacheDir);
+                System.err.println("Cache exists but is not a directory: "+cacheDir);
+                cacheDirOk = false;
             }
         } else {
             if (!cacheDir.mkdirs()) {
-                throw new IOException ("Can not create cache at "+cacheDir);
+                System.err.println("Can not create cache at "+cacheDir);
+                cacheDirOk = false;
+            }
+        }
+        if (!cacheDirOk) {
+            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx/cache/" + jfxVersion;
+            cacheDir = new File(tmpCache);
+            if (cacheDir.exists()) {
+                if (!cacheDir.isDirectory()) {
+                    throw new IOException("Cache exists but is not a directory: "+cacheDir);
+                }
+            } else {
+                if (!cacheDir.mkdirs()) {
+                    throw new IOException("Can not create cache at "+cacheDir);
+                }
             }
         }
         // we have a cache directory. Add the file here

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -239,6 +239,10 @@ public class NativeLibLoader {
                 cacheDirOk = false;
             }
         }
+        if (!cacheDir.canRead()) {
+            // on some systems, directories in user.home can be written but not read.
+            cacheDirOk = false;
+        }
         if (!cacheDirOk) {
             String username = System.getProperty("user.name", "anonymous");
             String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx_" + username + "/cache/" + jfxVersion;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -241,7 +241,7 @@ public class NativeLibLoader {
         }
         if (!cacheDirOk) {
             String username = System.getProperty("user.name", "anonymous");
-            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx/"+username+"/cache/" + jfxVersion;
+            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx_" + username + "/cache/" + jfxVersion;
             cacheDir = new File(tmpCache);
             if (cacheDir.exists()) {
                 if (!cacheDir.isDirectory()) {


### PR DESCRIPTION
* first check for a new property "javafx.cacheDir"
* if that exists, use it
* it not, use user.home directory
* if a cache directory can't be created under user.home, use java.io.tmpdir