### PR TITLE
WIP: JDK-8214158 : (JavaFX) Default to open for document opening on macOS

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
@@ -136,7 +136,11 @@ public abstract class HostServicesDelegate {
             String osName = System.getProperty("os.name");
             try {
                 if (osName.startsWith("Mac OS")) {
-                    Desktop.getDesktop().browse(URI.create(uri));
+                    try {
+                        Runtime.getRuntime().exec(new String[]{"open", uri});
+                    } catch (Exception e) {
+                        Desktop.getDesktop().browse(URI.create(uri));
+                    }
                 } else if (osName.startsWith("Windows")) {
                     Runtime.getRuntime().exec(
                             "rundll32 url.dll,FileProtocolHandler " + uri);


### PR DESCRIPTION
WIP/draft for now, have to ensure a few things first and also a kind of open question down below, but should be the general idea.

----

Fixes #294. Unsure if the try-catch is needed. I guess it's a light price to pay to ensure (almost) total backwards compatibility in the matter although it is definitely not really needed as macOS environments are much less different from one to the other than Linux ones.

Let me know your thoughts on whether to straight-up replace the previous command or keep this proposed wrapping.