### PR TITLE
 Remove final from HashSet instance (JDK-8215686)

### DIFF
--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
@@ -102,7 +102,7 @@ class NativeCompileTask extends DefaultTask {
         updateFiles();
         def source = project.files(allFiles);
         boolean forceCompile = false;
-        final Set<File> files = new HashSet<File>();
+        Set<File> files = new HashSet<File>();
         source.each { File file ->
             final Map fileData = dependencies.get(file.toString());
             final boolean isModified = fileData == null ||


### PR DESCRIPTION
Removes final from HashSet instance in buildSrc/src/main/groovy/com/sun/javafx/NativeCompileTask.groovy at about line 107 which causes build failure. There is no negative impact by doing this as code after the instance is created requires that the HashSet instance be mutable to begin with.