### PR TITLE
JDK-8211399: libxslt fails to build with glibc 2.26(#234)

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/config.h
@@ -143,7 +143,7 @@
 #define HAVE_VSPRINTF 1
 
 /* Define to 1 if you have the <xlocale.h> header file. */
-#define HAVE_XLOCALE_H 1
+/* #undef HAVE_XLOCALE_H */
 
 /* Define to 1 if you have the `_stat' function. */
 /* #undef HAVE__STAT */


### PR DESCRIPTION
https://github.com/javafxports/openjdk-jfx/issues/234