### PR TITLE
JDK-8215799: [Windows] Complex texts are not rendered properly

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -1024,6 +1024,10 @@ public abstract class PrismFontFactory implements FontFactory {
         fontRegInfo[0].add(jreFontDir + jreDefaultFontFile);
         fontRegInfo[1].add(jreDefaultFont);
 
+        // Add Arial Unicode to Windows fallback list
+        fontRegInfo[0].add(getPathNameWindows("arialuni.ttf"));
+        fontRegInfo[1].add("Arial Unicode MS");
+
         if (PlatformUtil.isWinVistaOrLater()) {
             // CJK Ext B Supplementary character fallbacks.
             fontRegInfo[0].add(getPathNameWindows("mingliub.ttc"));

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/ComplexTextControllerJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/ComplexTextControllerJava.cpp
@@ -92,6 +92,10 @@ unsigned jGetEnd(jobject jRun)
 
 unsigned jGetCharOffset(jobject jRun, unsigned glyphIndex)
 {
+    if (!jGetGlyphCount(jRun)) {
+        return { };
+    }
+
     JNIEnv* env = WebCore_GetJavaEnv();
     static jmethodID mID = env->GetMethodID(
         PG_GetTextRun(env),


### PR DESCRIPTION
WebKit uses GlyphPage table to quickly decide whether any glyph is available for given character. For our JavaFX port, we get char to glyph mapping using CharToGlyphMapper. 

On macOS and Linux it is working because the LogicalFont had valid fallback for complex texts also, but it is missing for Windows. Refer PrismFontFactory.getLinkedFonts. 

606.1 WebKit used GlyphTable only for simple texts, however 607.1 uses the same for complex texts also. 

I could think of the following workarounds., 

1) Add "Arial Unicode MS Regular" as a fallback for Windows, it has almost all glyphs for the unicode range. 
2) Call "TextLayout.getRuns" before invoking "CharToGlyphMapper", "TextLayout.getRuns" finds & adds the native fallback font. 