### PR TITLE
JDK-8216377: Fix memoryleak for initial nodes of Window

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1080,7 +1080,7 @@ public abstract class Node implements EventTarget, Styleable {
             oldScene.windowProperty().removeListener(sceneWindowChangedListener);
 
             Window window = oldScene.windowProperty().get();
-            if(window != null) {
+            if (window != null) {
                 window.showingProperty().removeListener(windowShowingChangedListener);
             }
         }
@@ -1088,7 +1088,7 @@ public abstract class Node implements EventTarget, Styleable {
             newScene.windowProperty().addListener(sceneWindowChangedListener);
 
             Window window = newScene.windowProperty().get();
-            if(window != null) {
+            if (window != null) {
                 window.showingProperty().addListener(windowShowingChangedListener);
             }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1078,9 +1078,20 @@ public abstract class Node implements EventTarget, Styleable {
         // isTreeShowing needs to take into account of Window's showing
         if (oldScene != null) {
             oldScene.windowProperty().removeListener(sceneWindowChangedListener);
+
+            Window window = oldScene.windowProperty().get();
+            if(window != null) {
+                window.showingProperty().removeListener(windowShowingChangedListener);
+            }
         }
         if (newScene != null) {
             newScene.windowProperty().addListener(sceneWindowChangedListener);
+
+            Window window = newScene.windowProperty().get();
+            if(window != null) {
+                window.showingProperty().addListener(windowShowingChangedListener);
+            }
+
         }
         updateTreeShowing();
 

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.javafx.scene;
 
 import javafx.application.Application;

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -1,0 +1,77 @@
+package test.javafx.scene;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import junit.framework.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public class InitialNodesMemoryLeakTest {
+
+    static CountDownLatch startupLatch;
+    static WeakReference<Group> toCleanUp;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            toCleanUp = new WeakReference<>(new Group());
+
+            Group root = new Group(toCleanUp.get());
+
+            stage.setScene(new Scene(root));
+
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> {
+                Platform.runLater(() -> {
+                    root.getChildren().clear();
+                    startupLatch.countDown();
+                });
+            });
+
+            stage.show();
+
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(InitialNodesMemoryLeakTest.TestApp.class, (String[])null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testCleanup() throws Exception {
+        System.out.println("got: " + toCleanUp.get());
+
+        for (int j = 0; j < 10; j++) {
+            System.gc();
+            System.runFinalization();
+
+            if (toCleanUp.get() == null) {
+                break;
+            }
+
+            Util.sleep(500);
+        }
+
+        Assert.assertTrue("Couldn't collect Node", toCleanUp.get() == null);
+    }
+}


### PR DESCRIPTION
BugID: [JDK-8216377](https://bugs.openjdk.java.net/browse/JDK-8216377)

While working on an update for [JPro](https://www.jpro.one/), I've found out, that a unit test for a memory leak doesn't work on JavaFX11. It's a regression and doesn't happen on JavaFX8

The initial nodes of a Scene are not collected by the GC when they are removed from the Scene.
They get collected when the initial Window is closed, but this is too late and not the expected behavior.

Affected JavaFX versions: 9 10 11 develop


This happens because the listener windowShowingChangedListener is not removed from the old Window, when the Scene is Changed.
This commit makes sure, that this listener is properly removed.

This bug would create a memory leak for every node inside a window if there wouldn't be another bug.
The listener windowShowingChangedListener is only added to the Scene when the window is changed.
I'm pretty sure, this is not intentionally and also fixed with this commit.
This might fix an unknown rendering related bug.

This commit also contains an unit-test to make sure no regression will happen.