### PR TITLE
JDK-8215435: Warn on usage of trampolines with gcc

### DIFF
--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ LINUX.library = { name -> return "lib${name}.so" as String }
 def commonFlags = [
         "-fno-strict-aliasing", "-fPIC", "-fno-omit-frame-pointer", // optimization flags
         "-fstack-protector",
-        "-Wextra", "-Wall", "-Wformat-security", "-Wno-unused", "-Wno-parentheses", "-Werror=implicit-function-declaration"] // warning flags
+        "-Wextra", "-Wall", "-Wformat-security", "-Wno-unused", "-Wno-parentheses", "-Werror=implicit-function-declaration", "-Werror=trampolines"] // warning flags
 
 if (!IS_64) {
     commonFlags += "-m32"

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
@@ -23,6 +23,7 @@ CFLAGS = -fPIC                   \
          -Wformat-security       \
          -fstack-protector       \
          -Werror=implicit-function-declaration \
+         -Werror=trampolines     \
          -msse2                  \
          -fbuiltin               \
          -DHAVE_STDINT_H         \

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
@@ -20,6 +20,7 @@ CFLAGS = -fPIC                   \
          -Wformat-security       \
          -fstack-protector       \
          -Werror=implicit-function-declaration \
+         -Werror=trampolines     \
          -msse2                  \
          -fbuiltin               \
          -DHAVE_STDINT_H         \

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
@@ -43,6 +43,7 @@ CFLAGS =-fPIC                   \
         -Wformat-security       \
         -fstack-protector       \
         -Werror=implicit-function-declaration \
+        -Werror=trampolines     \
         -D_GNU_SOURCE           \
         -DGST_REMOVE_DEPRECATED \
         -DGSTREAMER_LITE        \

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
@@ -42,6 +42,7 @@ ifdef HOST_COMPILE
                   -Wformat-security \
                   -fstack-protector \
                   -Werror=implicit-function-declaration \
+                  -Werror=trampolines \
 		  -msse2 \
 	          -DGSTREAMER_LITE
 


### PR DESCRIPTION
This is a fix for [JDK-8215435](https://bugs.openjdk.java.net/browse/JDK-8215435). It adds the `-Werror=trampolines` flag to the gcc build, which will fail the build if trampolines are generated for pointers to nested functions (we currently have none so this is a protection against future changes). Trampolines require executable stacks and are an anti-pattern. A corresponding JDK build change was also done for JDK 12 (see [JDK-8215400](https://bugs.openjdk.java.net/browse/JDK-8215400)).
