### PR TITLE
JDK-8217333: Pass additional arguments to gradle from build.ps1

### DIFF
--- a/tools/scripts/build.ps1
+++ b/tools/scripts/build.ps1
@@ -1,4 +1,7 @@
-param ([switch]$nocygwin = $false)
+param (
+[switch]$nocygwin = $false,
+[parameter(ValueFromRemainingArguments)][String[]]$args
+)
 
 choco install ant
 choco install vswhere
@@ -20,7 +23,7 @@ if ([string]::IsNullOrWhitespace($vsRoot)) {
 $winSdk = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots").KitsRoot10 2>$null
 if ([string]::IsNullOrWhitespace($winSdk)) {
   choco install windows-sdk-7.1
-  $winSdk = ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots" -ErrorAction Stop).KitsRoot10) 
+  $winSdk = ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots" -ErrorAction Stop).KitsRoot10)
 }
 
 # Cygwin required for chmod
@@ -62,8 +65,8 @@ if ($env:APPVEYOR -eq "true") {
   }
 } else {
   if ($noCygwin) {
-    .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug -PUSE_CYGWIN=false --stacktrace -x :web:test --info --no-daemon
+    .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug -PUSE_CYGWIN=false --stacktrace -x :web:test --info --no-daemon $args
   } else {
-    .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug --stacktrace -x :web:test --info --no-daemon
+    .\gradlew all test -PCOMPILE_WEBKIT=false -PCONF=Debug --stacktrace -x :web:test --info --no-daemon $args
   }
 }


### PR DESCRIPTION
If there are any extra parameters passed in to .\tools\scripts\build.ps1
that are not used by the script itself, then pass any additional
parameters through to gradle.

This allows for the following:

.\tools\scripts\build.ps1 -nocygwin --tests *SomeTest

Where the "--tests *SomeTest" bit is actually an argument for gradle,
not the powershell build script.