### PR TITLE
JDK-8215702: SVG gradients are not rendered

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,9 @@ static void setGradient(Gradient &gradient, PlatformGraphicsContext* context, ji
                 endRadius = data.endRadius;
             }
     );
+
+    p0 = gt.mapPoint(p0);
+    p1 = gt.mapPoint(p1);
 
     context->rq().freeSpace(4 * 11 + 8 * nStops)
     << id

--- a/modules/javafx.web/src/shims/java/com/sun/javafx/webkit/prism/WCBufferedContextShim.java
+++ b/modules/javafx.web/src/shims/java/com/sun/javafx/webkit/prism/WCBufferedContextShim.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.webkit.prism;
+
+import com.sun.javafx.webkit.prism.PrismImage;
+import com.sun.webkit.graphics.WCGraphicsContext;
+import com.sun.webkit.graphics.WCGraphicsManagerShim;
+import com.sun.webkit.graphics.WCImage;
+
+public class WCBufferedContextShim {
+    public static WCGraphicsContext createBufferedContext(int w, int h) {
+        final WCImage img = WCGraphicsManagerShim.createRTImage(w, h);
+        return new WCBufferedContext((PrismImage) img);
+    }
+}
+

--- a/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
+++ b/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,15 @@
 
 package com.sun.webkit;
 
+import com.sun.javafx.webkit.prism.WCBufferedContextShim;
 import com.sun.webkit.WebPage;
 import com.sun.webkit.event.WCMouseEvent;
 import com.sun.webkit.graphics.WCGraphicsContext;
 import com.sun.webkit.graphics.WCGraphicsManager;
+import com.sun.webkit.graphics.WCGraphicsManagerShim;
 import com.sun.webkit.graphics.WCPageBackBuffer;
 import com.sun.webkit.graphics.WCRectangle;
+import java.awt.image.BufferedImage;
 
 public class WebPageShim {
 
@@ -42,10 +45,13 @@ public class WebPageShim {
         page.setBounds(x, y, w, h);
         // forces layout and renders the page into RenderQueue.
         page.updateContent(new WCRectangle(x, y, w, h));
+        return WCBufferedContextShim.createBufferedContext(w, h);
+    }
 
-        final WCPageBackBuffer buffer = WCGraphicsManager.getGraphicsManager().createPageBackBuffer();
-        buffer.validate(w, h);
-        return buffer.createGraphics();
+    public static BufferedImage paint(WebPage page, int x, int y, int w, int h) {
+        final WCGraphicsContext gc = setupPageWithGraphics(page, x, y, w, h);
+        page.paint(gc, x, y, w, h);
+        return gc.getImage().toBufferedImage();
     }
 
     public static void mockPrint(WebPage page, int x, int y, int w, int h) {

--- a/modules/javafx.web/src/shims/java/com/sun/webkit/graphics/WCGraphicsManagerShim.java
+++ b/modules/javafx.web/src/shims/java/com/sun/webkit/graphics/WCGraphicsManagerShim.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.graphics;
+
+import com.sun.webkit.graphics.WCGraphicsManager;
+import com.sun.webkit.graphics.WCImage;
+
+public class WCGraphicsManagerShim {
+
+    public static WCImage createRTImage(int w, int h) {
+        return WCGraphicsManager.getGraphicsManager().createRTImage(w, h);
+    }
+}

--- a/modules/javafx.web/src/test/addExports
+++ b/modules/javafx.web/src/test/addExports
@@ -48,9 +48,11 @@
 --add-exports javafx.graphics/com.sun.scenario=ALL-UNNAMED
 #
 --add-exports javafx.web/com.sun.javafx.scene.web=ALL-UNNAMED
+--add-exports javafx.web/com.sun.javafx.webkit.prism=ALL-UNNAMED
 --add-exports javafx.web/com.sun.javafx.webkit=ALL-UNNAMED
---add-exports javafx.web/com.sun.webkit=ALL-UNNAMED
 --add-exports javafx.web/com.sun.webkit.dom=ALL-UNNAMED
 --add-exports javafx.web/com.sun.webkit.event=ALL-UNNAMED
+--add-exports javafx.web/com.sun.webkit.graphics=ALL-UNNAMED
 --add-exports javafx.web/com.sun.webkit.network=ALL-UNNAMED
 --add-exports javafx.web/com.sun.webkit.text=ALL-UNNAMED
+--add-exports javafx.web/com.sun.webkit=ALL-UNNAMED

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package test.javafx.scene.web;
 
 import java.awt.Color;
-import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -124,21 +123,6 @@ public class CanvasTest extends TestBase {
             assertEquals("Arc endAngle", redColor,
                     (int) getEngine().executeScript("document.getElementById('canvas').getContext('2d').getImageData(300,75,1,1).data[0]"));
         });
-    }
-
-    // Color comparison algorithm is based on WebKit's Tools/ImageDiff/PlaformImage.cpp#PlatformImage::difference implemenation.
-    // https://trac.webkit.org/browser/webkit/trunk/Tools/ImageDiff/PlatformImage.cpp
-    private static float getColorDifference(final Color base, final Color c) {
-        final float red = (c.getRed() - base.getRed()) / Math.max(255.0f - base.getRed(), base.getRed());
-        final float green = (c.getGreen() - base.getGreen()) / Math.max(255.0f - base.getGreen(), base.getGreen());
-        final float blue = (c.getBlue() - base.getBlue()) / Math.max(255.0f - base.getBlue(), base.getBlue());
-        final float alpha = (c.getAlpha() - base.getAlpha()) / Math.max(255.0f - base.getAlpha(), base.getAlpha());
-        final float distance = ((float) Math.sqrt(red * red + green * green + blue * blue + alpha * alpha)) / 2.0f;
-        return distance >= (1 / 255.0f) ? distance * 100.0f : 0;
-    }
-
-    private static boolean isColorsSimilar(final Color base, final Color c, float toleranceInPercentage) {
-        return toleranceInPercentage >= getColorDifference(base, c);
     }
 
     private BufferedImage htmlCanvasToBufferedImage(final String mime) throws Exception {

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/TestBase.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.web;
 
+import java.awt.Color;
 import java.io.File;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -299,5 +300,20 @@ public class TestBase implements ChangeListener, InvalidationListener {
         } catch (Exception e) { }
 
         return clazz != null;
+    }
+
+    // Color comparison algorithm is based on WebKit's Tools/ImageDiff/PlaformImage.cpp#PlatformImage::difference implemenation.
+    // https://trac.webkit.org/browser/webkit/trunk/Tools/ImageDiff/PlatformImage.cpp
+    protected static float getColorDifference(final Color base, final Color c) {
+        final float red = (c.getRed() - base.getRed()) / Math.max(255.0f - base.getRed(), base.getRed());
+        final float green = (c.getGreen() - base.getGreen()) / Math.max(255.0f - base.getGreen(), base.getGreen());
+        final float blue = (c.getBlue() - base.getBlue()) / Math.max(255.0f - base.getBlue(), base.getBlue());
+        final float alpha = (c.getAlpha() - base.getAlpha()) / Math.max(255.0f - base.getAlpha(), base.getAlpha());
+        final float distance = ((float) Math.sqrt(red * red + green * green + blue * blue + alpha * alpha)) / 2.0f;
+        return distance >= (1 / 255.0f) ? distance * 100.0f : 0;
+    }
+
+    protected static boolean isColorsSimilar(final Color base, final Color c, float toleranceInPercentage) {
+        return toleranceInPercentage >= getColorDifference(base, c);
     }
 }


### PR DESCRIPTION
Gradient points are not mapped to the current transformation matrix. The fix was there before 606.1 upgrade, however during the merge it got missed out while incorporating the Gradient class related refactoring changes.