### PR TITLE
JDK-8205092: Added dirty check for viewOrderChildren

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -194,7 +194,8 @@ public abstract class Parent extends Node {
         }
 
         if (isDirty(DirtyBits.PARENT_CHILDREN_VIEW_ORDER)) {
-            computeViewOrderChildrenAndUpdatePeer();
+            computeViewOrderChildren();
+            peer.setViewOrderChildren(viewOrderChildren);
         }
 
         if (Utils.assertionEnabled()) validatePG();
@@ -265,7 +266,7 @@ public abstract class Parent extends Node {
         NodeHelper.markDirty(this, DirtyBits.PARENT_CHILDREN_VIEW_ORDER);
     }
 
-    private void computeViewOrderChildrenAndUpdatePeer() {
+    private void computeViewOrderChildren() {
         boolean viewOrderSet = false;
         for (Node child : children) {
             double vo = child.getViewOrder();
@@ -284,9 +285,6 @@ public abstract class Parent extends Node {
                     -> a.getViewOrder() < b.getViewOrder() ? 1
                             : a.getViewOrder() == b.getViewOrder() ? 0 : -1);
         }
-
-        final NGGroup peer = getPeer();
-        peer.setViewOrderChildren(viewOrderChildren);
     }
 
     // Call this method if children view order is needed for picking.
@@ -294,7 +292,7 @@ public abstract class Parent extends Node {
     private List<Node> getOrderedChildren() {
         if (isDirty(DirtyBits.PARENT_CHILDREN_VIEW_ORDER)) {
             //Fix for JDK-8205092
-            computeViewOrderChildrenAndUpdatePeer();
+            computeViewOrderChildren();
         }
         if (!viewOrderChildren.isEmpty()) {
             return viewOrderChildren;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,6 +292,10 @@ public abstract class Parent extends Node {
     // Call this method if children view order is needed for picking.
     // The returned list should be treated as read only.
     private List<Node> getOrderedChildren() {
+        if (isDirty(DirtyBits.PARENT_CHILDREN_VIEW_ORDER)) {
+            //Fix for JDK-8205092
+            computeViewOrderChidrenAndUpdatePeer();
+        }
         if (!viewOrderChildren.isEmpty()) {
             return viewOrderChildren;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -194,7 +194,7 @@ public abstract class Parent extends Node {
         }
 
         if (isDirty(DirtyBits.PARENT_CHILDREN_VIEW_ORDER)) {
-            computeViewOrderChidrenAndUpdatePeer();
+            computeViewOrderChildrenAndUpdatePeer();
         }
 
         if (Utils.assertionEnabled()) validatePG();
@@ -265,7 +265,7 @@ public abstract class Parent extends Node {
         NodeHelper.markDirty(this, DirtyBits.PARENT_CHILDREN_VIEW_ORDER);
     }
 
-    private void computeViewOrderChidrenAndUpdatePeer() {
+    private void computeViewOrderChildrenAndUpdatePeer() {
         boolean viewOrderSet = false;
         for (Node child : children) {
             double vo = child.getViewOrder();
@@ -294,7 +294,7 @@ public abstract class Parent extends Node {
     private List<Node> getOrderedChildren() {
         if (isDirty(DirtyBits.PARENT_CHILDREN_VIEW_ORDER)) {
             //Fix for JDK-8205092
-            computeViewOrderChidrenAndUpdatePeer();
+            computeViewOrderChildrenAndUpdatePeer();
         }
         if (!viewOrderChildren.isEmpty()) {
             return viewOrderChildren;

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -742,7 +742,7 @@ public class ParentTest {
 
         assertSame(scene, ParentShim.getChildren(child).get(3).getScene());
     }
-    
+
     @Test
     public void testPickingChildNode(){
         Rectangle rect1 = new Rectangle();
@@ -750,7 +750,7 @@ public class ParentTest {
         rect1.setY(10);
         rect1.setWidth(100);
         rect1.setHeight(100);
-        
+
         Rectangle rect2 = new Rectangle();
         rect2.setX(10);
         rect2.setY(10);
@@ -772,7 +772,7 @@ public class ParentTest {
         NodeHelper.pickNode(g, new PickRay(0, 0, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
         assertNull(res.getIntersectedNode());
     }
-    
+
     @Test
     public void testPickingChildNodeWithViewOrderSet(){
         Rectangle rect1 = new Rectangle();
@@ -781,7 +781,7 @@ public class ParentTest {
         rect1.setWidth(100);
         rect1.setHeight(100);
         rect1.setViewOrder(-1);
-        
+
         Rectangle rect2 = new Rectangle();
         rect2.setX(10);
         rect2.setY(10);
@@ -803,7 +803,7 @@ public class ParentTest {
         NodeHelper.pickNode(g, new PickRay(0, 0, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
         assertNull(res.getIntersectedNode());
     }
-    
+
     @Test
     public void testPickingChildNodeWithDirtyViewOrder(){
         //JDK-8205092
@@ -813,7 +813,7 @@ public class ParentTest {
         rect1.setWidth(100);
         rect1.setHeight(100);
         rect1.setViewOrder(-1);
-        
+
         Rectangle rect2 = new Rectangle();
         rect2.setX(10);
         rect2.setY(10);
@@ -827,7 +827,7 @@ public class ParentTest {
         stage.show();
         ParentShim.getChildren(g).addAll(rect1,rect2);
         toolkit.fireTestPulse();
-        
+
         ParentShim.getChildren(g).remove(rect1);
 
         PickResultChooser res = new PickResultChooser();

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -744,7 +744,7 @@ public class ParentTest {
     }
 
     @Test
-    public void testPickingChildNode(){
+    public void testPickingChildNode() {
         Rectangle rect1 = new Rectangle();
         rect1.setX(10);
         rect1.setY(10);
@@ -762,7 +762,7 @@ public class ParentTest {
         Scene scene = new Scene(g);
         stage.setScene(scene);
         stage.show();
-        ParentShim.getChildren(g).addAll(rect1,rect2);
+        ParentShim.getChildren(g).addAll(rect1, rect2);
         toolkit.fireTestPulse();
 
         PickResultChooser res = new PickResultChooser();
@@ -774,7 +774,7 @@ public class ParentTest {
     }
 
     @Test
-    public void testPickingChildNodeWithViewOrderSet(){
+    public void testPickingChildNodeWithViewOrderSet() {
         Rectangle rect1 = new Rectangle();
         rect1.setX(10);
         rect1.setY(10);
@@ -793,7 +793,7 @@ public class ParentTest {
         Scene scene = new Scene(g);
         stage.setScene(scene);
         stage.show();
-        ParentShim.getChildren(g).addAll(rect1,rect2);
+        ParentShim.getChildren(g).addAll(rect1, rect2);
         toolkit.fireTestPulse();
 
         PickResultChooser res = new PickResultChooser();
@@ -805,7 +805,7 @@ public class ParentTest {
     }
 
     @Test
-    public void testPickingChildNodeWithDirtyViewOrder(){
+    public void testPickingChildNodeWithDirtyViewOrder() {
         //JDK-8205092
         Rectangle rect1 = new Rectangle();
         rect1.setX(10);
@@ -825,7 +825,7 @@ public class ParentTest {
         Scene scene = new Scene(g);
         stage.setScene(scene);
         stage.show();
-        ParentShim.getChildren(g).addAll(rect1,rect2);
+        ParentShim.getChildren(g).addAll(rect1, rect2);
         toolkit.fireTestPulse();
 
         ParentShim.getChildren(g).remove(rect1);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import com.sun.javafx.scene.NodeHelper;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.sg.prism.NGGroup;
 import com.sun.javafx.tk.Toolkit;
+import com.sun.javafx.geom.PickRay;
+import com.sun.javafx.scene.input.PickResultChooser;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.scene.Group;
 import javafx.scene.GroupShim;
@@ -739,6 +741,101 @@ public class ParentTest {
         ParentShim.getChildren(root).add(child);
 
         assertSame(scene, ParentShim.getChildren(child).get(3).getScene());
+    }
+    
+    @Test
+    public void testPickingChildNode(){
+        Rectangle rect1 = new Rectangle();
+        rect1.setX(10);
+        rect1.setY(10);
+        rect1.setWidth(100);
+        rect1.setHeight(100);
+        
+        Rectangle rect2 = new Rectangle();
+        rect2.setX(10);
+        rect2.setY(10);
+        rect2.setWidth(100);
+        rect2.setHeight(100);
+        Group g = new Group();
+
+        // needed since picking doesn't work unless rooted in a scene and visible
+        Scene scene = new Scene(g);
+        stage.setScene(scene);
+        stage.show();
+        ParentShim.getChildren(g).addAll(rect1,rect2);
+        toolkit.fireTestPulse();
+
+        PickResultChooser res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(50, 50, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertSame(rect2, res.getIntersectedNode());
+        res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(0, 0, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertNull(res.getIntersectedNode());
+    }
+    
+    @Test
+    public void testPickingChildNodeWithViewOrderSet(){
+        Rectangle rect1 = new Rectangle();
+        rect1.setX(10);
+        rect1.setY(10);
+        rect1.setWidth(100);
+        rect1.setHeight(100);
+        rect1.setViewOrder(-1);
+        
+        Rectangle rect2 = new Rectangle();
+        rect2.setX(10);
+        rect2.setY(10);
+        rect2.setWidth(100);
+        rect2.setHeight(100);
+        Group g = new Group();
+
+        // needed since picking doesn't work unless rooted in a scene and visible
+        Scene scene = new Scene(g);
+        stage.setScene(scene);
+        stage.show();
+        ParentShim.getChildren(g).addAll(rect1,rect2);
+        toolkit.fireTestPulse();
+
+        PickResultChooser res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(50, 50, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertSame(rect1, res.getIntersectedNode());
+        res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(0, 0, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertNull(res.getIntersectedNode());
+    }
+    
+    @Test
+    public void testPickingChildNodeWithDirtyViewOrder(){
+        //JDK-8205092
+        Rectangle rect1 = new Rectangle();
+        rect1.setX(10);
+        rect1.setY(10);
+        rect1.setWidth(100);
+        rect1.setHeight(100);
+        rect1.setViewOrder(-1);
+        
+        Rectangle rect2 = new Rectangle();
+        rect2.setX(10);
+        rect2.setY(10);
+        rect2.setWidth(100);
+        rect2.setHeight(100);
+        Group g = new Group();
+
+        // needed since picking doesn't work unless rooted in a scene and visible
+        Scene scene = new Scene(g);
+        stage.setScene(scene);
+        stage.show();
+        ParentShim.getChildren(g).addAll(rect1,rect2);
+        toolkit.fireTestPulse();
+        
+        ParentShim.getChildren(g).remove(rect1);
+
+        PickResultChooser res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(50, 50, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertSame(rect2, res.getIntersectedNode());
+        res = new PickResultChooser();
+        NodeHelper.pickNode(g, new PickRay(0, 0, 1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), res);
+        assertNull(res.getIntersectedNode());
     }
 
     public static class MockParent extends Parent {


### PR DESCRIPTION
If the scene graph is modified while handling a mouse event, viewOrderChildren can contain nodes which are no longer in the scene graph, causing an NPE in PickResultChooser.processOffer. This is fairly rare, and only affects parent nodes with children that have a view order set. testPickingChildNodeWithDirtyViewOrder replicates these conditions and results in the same NPE as reported in the bug report.

This solution doesn't unset the dirty bits because I'm unsure of the consequences. In the worst case the viewOrderChildren will be recalculated one extra time because of this.

An alternative solution is to keep viewOrderChildren in sync with the children list, however that would mean sorting it whenever the view order property of a child is changed (the child calls markViewOrderChildrenDirty of its parent when this happens). That could happen many times. Updating the list as it's needed seems like a better solution to me.