### PR TITLE
JDK-8213806: WebView - JVM crashes for given HTML

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/URLHash.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/URLHash.h
@@ -35,7 +35,7 @@ namespace WebCore {
     struct URLHash {
         static unsigned hash(const URL& key)
         {
-            return key.string().impl()->hash();
+            return key.string().hash();
         }
 
         static bool equal(const URL& a, const URL& b)

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -497,4 +497,31 @@ public class MiscellaneousTest extends TestBase {
             assertTrue("Color should be opaque yellow:" + pixelAt399x145, isColorsSimilar(Color.YELLOW, pixelAt399x145, 1));
         });
     }
+
+    @Test public void testShadowDOMWithLoadContent() {
+        loadContent("<html>\n" +
+                    "  <body>\n" +
+                    "    <template id='element-details-template'>\n" +
+                    "      <style>\n" +
+                    "        p { font-weight: bold; }\n" +
+                    "      </style>\n" +
+                    "    </template>\n" +
+                    "    <element-details>\n" +
+                    "    </element-details>\n" +
+                    "    <script>\n" +
+                    "    customElements.define('element-details',\n" +
+                    "      class extends HTMLElement {\n" +
+                    "        constructor() {\n" +
+                    "          super();\n" +
+                    "          const template = document\n" +
+                    "            .getElementById('element-details-template')\n" +
+                    "            .content;\n" +
+                    "          const shadowRoot = this.attachShadow({mode: 'open'})\n" +
+                    "            .appendChild(template.cloneNode(true));\n" +
+                    "        }\n" +
+                    "      })\n" +
+                    "    </script>\n" +
+                    "  </body>\n" +
+                    "</html>");
+    }
 }


### PR DESCRIPTION
### Root cause
"baseURL" is set to empty(null) when loading the html string using `WebEngine.loadContent` API. The URL has been used as one of the key while caching the inline CSS style content for Shadow Root(Shadow DOM). While calculating the hash value for the key, `URLHash::hash` method calls the `StringImpl::hash` method without checking for null.

It is not observed on other WebKit ports because they expose loadContent API which also takes baseURL. See [WKWebView::loadHTMLString](https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring?language=objc).

We also should consider to provide another variant of `WebEngine.loadContent` which takes `baseURL` as a parameter.

### Solution
Use to `String::hash` instead of `StringImpl::hash` from `URLHash::hash`. `String::hash` still calls `StringImpl::hash` after testing for null.