### PR TITLE
JDK-8217492: memory leak after the event WindowEvent.DESTROY

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -832,7 +832,10 @@ class WindowStage extends GlassStage {
     // closed notification. This state is necessary to prevent the platform
     // window from being closed more than once.
     void setPlatformWindowClosed() {
-        platformWindow = null;
+        if(platformWindow != null) {
+            platformWindows.remove(platformWindow);
+            platformWindow = null;
+        }
     }
 
     static void addActiveWindow(WindowStage window) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -832,7 +832,7 @@ class WindowStage extends GlassStage {
     // closed notification. This state is necessary to prevent the platform
     // window from being closed more than once.
     void setPlatformWindowClosed() {
-        if(platformWindow != null) {
+        if (platformWindow != null) {
             platformWindows.remove(platformWindow);
             platformWindow = null;
         }


### PR DESCRIPTION
ticket: https://bugs.openjdk.java.net/projects/JDK/issues/JDK-8217492?filter=allopenissues

I've seen it on openjfx-8, but I'm sure it can also happen on 11 and 12, because the current code isn't very reasonable. 
Sadly I don't know how to reproduce it.


Explanation:
The most relevant class for this issue is com.sun.javafx.tk.quantum.StageWindow.
When the bug happens, a StageWindow gets registered in the static HashMap platformWindows but newer get's removed.
Usually, the HashMaps gets cleared, when StageWindow.closed is called.
But when StageWindow.setPlatformWindowClosed gets called, which only happens on a WindowEvent.DESTROY,
then the reference platformWindow get nulled, but the hashmap platformWindows never gets cleaned up.


Solution:
StageWindow.setPlatformWindowClosed must be changed, to cleanup platformWindows.
This change shouldn't cause any problems, because platformWindows is only used in PaintCollecter.
This usage contains a null-check and not rendering the destroyed window shouldn't have any effect.


Reproduce:
The bug can be reproduced, by creating a WindowEvent.DESTROY event, but I don't know how to create such an event.

I found the memory leak inside a heap dump from a server running JPro (https://jpro.one).
After 600 opened Stages, the memory leak happened twice.

It's save to assume that this bug also happens on the desktop.
It might happen much more often on a specific OS or applications.

Testing:
I don't know how to trigger this bug, nor do i have a good idea, how to write a test for it.
For now, I'm only providing a fix for the problem.