### PR TITLE
JDK-8201539: WICCreateImagingFactory: defer CoUninitialize() call to thread exit (dispose hook approach)

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -122,7 +122,7 @@ public class DWFactory extends PrismFontFactory {
         /* Using single threaded WIC Factory as it should only be used by the rendering thread */
         if (WIC_FACTORY == null) {
             /* Initialize COM in order to create a WICImagingFactory.
-             * It runs on the prism thread and expects no other codes in this thread
+             * It runs on the prism thread and expects no other code in this thread
              * to interface with COM. */
             if (!OS.CoInitializeEx(OS.COINIT_APARTMENTTHREADED | OS.COINIT_DISABLE_OLE1DDE)) {
                 return null;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -29,6 +29,8 @@ import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.PrismFontFile;
 import com.sun.javafx.text.GlyphLayout;
 
+import java.lang.reflect.Method;
+
 public class DWFactory extends PrismFontFactory {
 
     /* Factories (Singletons) */
@@ -116,11 +118,29 @@ public class DWFactory extends PrismFontFactory {
         }
     }
 
+    private static void addGraphicsPipelineDisposeHook(Runnable runnable) {
+        try {
+            Class plc = Class.forName("com.sun.prism.GraphicsPipeline");
+            Method gpm = plc.getMethod("getPipeline", (Class[])null);
+            Object plo = gpm.invoke(null);
+            Method adhm = plc.getMethod("addDisposeHook", Runnable.class);
+            adhm.invoke(plo, runnable);
+        } catch (Exception e) {
+        }
+    }
+
     static synchronized IWICImagingFactory getWICFactory() {
         checkThread();
         /* Using single threaded WIC Factory as it should only be used by the rendering thread */
         if (WIC_FACTORY == null) {
             WIC_FACTORY = OS.WICCreateImagingFactory();
+            addGraphicsPipelineDisposeHook(() -> {
+                checkThread();
+                WIC_FACTORY.Release();
+                /* Uninitialize COM as it was initialized by WICCreateImagingFactory() */
+                OS.CoUninitialize();
+                WIC_FACTORY = null;
+            });
         }
         return WIC_FACTORY;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -122,6 +122,9 @@ public class DWFactory extends PrismFontFactory {
         /* Using single threaded WIC Factory as it should only be used by the rendering thread */
         if (WIC_FACTORY == null) {
             WIC_FACTORY = OS.WICCreateImagingFactory();
+            if (WIC_FACTORY == null) {
+                return null;
+            }
             GraphicsPipeline.getPipeline().addDisposeHook(() -> {
                 checkThread();
                 WIC_FACTORY.Release();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -28,8 +28,7 @@ package com.sun.javafx.font.directwrite;
 import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.PrismFontFile;
 import com.sun.javafx.text.GlyphLayout;
-
-import java.lang.reflect.Method;
+import com.sun.prism.GraphicsPipeline;
 
 public class DWFactory extends PrismFontFactory {
 
@@ -118,23 +117,12 @@ public class DWFactory extends PrismFontFactory {
         }
     }
 
-    private static void addGraphicsPipelineDisposeHook(Runnable runnable) {
-        try {
-            Class plc = Class.forName("com.sun.prism.GraphicsPipeline");
-            Method gpm = plc.getMethod("getPipeline", (Class[])null);
-            Object plo = gpm.invoke(null);
-            Method adhm = plc.getMethod("addDisposeHook", Runnable.class);
-            adhm.invoke(plo, runnable);
-        } catch (Exception e) {
-        }
-    }
-
     static synchronized IWICImagingFactory getWICFactory() {
         checkThread();
         /* Using single threaded WIC Factory as it should only be used by the rendering thread */
         if (WIC_FACTORY == null) {
             WIC_FACTORY = OS.WICCreateImagingFactory();
-            addGraphicsPipelineDisposeHook(() -> {
+            GraphicsPipeline.getPipeline().addDisposeHook(() -> {
                 checkThread();
                 WIC_FACTORY.Release();
                 /* Uninitialize COM as it was initialized by WICCreateImagingFactory() */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -175,6 +175,8 @@ class OS {
         return ptr != 0 ? new IWICImagingFactory(ptr) : null;
     }
 
+    static final native void CoUninitialize();
+
     private static final native long _NewJFXTextAnalysisSink(char[] text,
                                                              int start,
                                                              int length,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -42,6 +42,10 @@ class OS {
     static final int S_OK = 0x0;
     static final int E_NOT_SUFFICIENT_BUFFER = 0x8007007A;
 
+    /* COM init constants */
+    static final int COINIT_APARTMENTTHREADED = 0x2;
+    static final int COINIT_DISABLE_OLE1DDE = 0x4;
+
     /* Direct2D constants */
     static final int D2D1_FACTORY_TYPE_SINGLE_THREADED = 0;
     static final int D2D1_RENDER_TARGET_TYPE_DEFAULT    = 0;
@@ -175,6 +179,7 @@ class OS {
         return ptr != 0 ? new IWICImagingFactory(ptr) : null;
     }
 
+    static final native boolean CoInitializeEx(int dwCoInit);
     static final native void CoUninitialize();
 
     private static final native long _NewJFXTextAnalysisSink(char[] text,

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
@@ -31,9 +31,11 @@ import com.sun.javafx.font.PrismFontFactory;
 import com.sun.prism.impl.PrismSettings;
 
 import java.lang.reflect.Method;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class GraphicsPipeline {
 
@@ -56,10 +58,26 @@ public abstract class GraphicsPipeline {
         SM3
     }
     private FontFactory fontFactory;
+    private final Set<Runnable> disposeHooks = new HashSet<Runnable>();
 
     public abstract boolean init();
     public void dispose() {
+        for (Runnable disposeHook : disposeHooks) {
+            disposeHook.run();
+        }
         installedPipeline = null;
+    }
+
+    /**
+     * Add a dispose hook to be called when the pipeline is disposed.
+     *
+     * @param runnable the {@link Runnable} to be called when the pipeline is disposed
+     */
+    public void addDisposeHook(Runnable runnable) {
+        if (runnable == null) {
+            return;
+        }
+        disposeHooks.add(runnable);
     }
 
     public abstract int getAdapterOrdinal(Screen screen);

--- a/modules/javafx.graphics/src/main/native-font/directwrite.cpp
+++ b/modules/javafx.graphics/src/main/native-font/directwrite.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-font/directwrite.cpp
+++ b/modules/javafx.graphics/src/main/native-font/directwrite.cpp
@@ -845,6 +845,12 @@ jobject newD2D1_MATRIX_3X2_F(JNIEnv *env, D2D1_MATRIX_3X2_F *lpStruct)
 /*                                                                        */
 /**************************************************************************/
 
+JNIEXPORT void JNICALL OS_NATIVE(CoUninitialize)
+    (JNIEnv *env, jclass that)
+{
+    CoUninitialize();
+}
+
 JNIEXPORT jlong JNICALL OS_NATIVE(_1WICCreateImagingFactory)
     (JNIEnv *env, jclass that)
 {
@@ -867,8 +873,6 @@ JNIEXPORT jlong JNICALL OS_NATIVE(_1WICCreateImagingFactory)
             IID_PPV_ARGS(&result)
             );
 
-    /* Unload COM as no other COM objects will be create directly */
-    CoUninitialize();
     return SUCCEEDED(hr) ? (jlong)result : NULL;
 }
 

--- a/modules/javafx.graphics/src/main/native-font/directwrite.cpp
+++ b/modules/javafx.graphics/src/main/native-font/directwrite.cpp
@@ -854,7 +854,7 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(CoInitializeEx)
      * This should never happen. */
     if (hr == RPC_E_CHANGED_MODE) return JNI_FALSE;
 
-    return SUCCEEDED(hr) ? JNI_TRUE : JNI_FALSE;
+    return JNI_TRUE;
 }
 
 JNIEXPORT void JNICALL OS_NATIVE(CoUninitialize)

--- a/modules/javafx.graphics/src/main/native-font/directwrite.cpp
+++ b/modules/javafx.graphics/src/main/native-font/directwrite.cpp
@@ -845,6 +845,18 @@ jobject newD2D1_MATRIX_3X2_F(JNIEnv *env, D2D1_MATRIX_3X2_F *lpStruct)
 /*                                                                        */
 /**************************************************************************/
 
+JNIEXPORT jboolean JNICALL OS_NATIVE(CoInitializeEx)
+    (JNIEnv *env, jclass that, jint arg0)
+{
+    HRESULT hr = CoInitializeEx(NULL, (DWORD)arg0);
+
+    /* This means COM has been initialized with a different concurrency model.
+     * This should never happen. */
+    if (hr == RPC_E_CHANGED_MODE) return JNI_FALSE;
+
+    return SUCCEEDED(hr) ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL OS_NATIVE(CoUninitialize)
     (JNIEnv *env, jclass that)
 {
@@ -854,19 +866,8 @@ JNIEXPORT void JNICALL OS_NATIVE(CoUninitialize)
 JNIEXPORT jlong JNICALL OS_NATIVE(_1WICCreateImagingFactory)
     (JNIEnv *env, jclass that)
 {
-    /* This routine initialize COM in order to create an WICImagingFactory.
-     * It runs on the prism thread and expects no other codes in this thread
-     * to interface with COM.
-     * Note: This method is called by DWFactory a single time.
-     */
-    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-
-    /* This means COM has been initialize with a different concurrency model.
-     * This should never happen. */
-    if (hr == RPC_E_CHANGED_MODE) return NULL;
-
     IWICImagingFactory* result = NULL;
-    hr = CoCreateInstance(
+    HRESULT hr = CoCreateInstance(
             CLSID_WICImagingFactory,
             NULL,
             CLSCTX_INPROC_SERVER,


### PR DESCRIPTION
GitHub issue: #66 
JBS Bug Link: https://bugs.openjdk.java.net/browse/JDK-8201539

The crash was occurring because the call to `CoUninitialize()` was done too early and resulted in `WindowsCodecs.dll` being prematurely unloaded even though `IWICImagingFactory` needed it. This caused a crash when `IWICImagingFactory` was accessed afterwards.

This is the "dispose hook approach" which adds a "dispose hook" mechanism to `GraphicsPipeline`. `DWFactory` is then taught to use this mechanism to call `CoUnitialize()` only when the `GraphicsPipeline` is being disposed (which occurs on QuantumRenderer shutdown).