### PR TITLE
JDK-8218424 - Use precise scrolling only when supported (#366)

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -455,9 +455,17 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     jdouble rotationY = 0.0;
     if (type == com_sun_glass_events_MouseEvent_WHEEL)
     {
-        rotationX = (jdouble)[theEvent scrollingDeltaX] * 0.1;
-        rotationY = (jdouble)[theEvent scrollingDeltaY] * 0.1;
-
+        if ([theEvent hasPreciseScrollingDeltas])
+        {
+            rotationX = (jdouble)[theEvent scrollingDeltaX] * 0.1;
+            rotationY = (jdouble)[theEvent scrollingDeltaY] * 0.1;
+        }
+        else
+        {
+            rotationX = (jdouble)[theEvent deltaX];
+            rotationY = (jdouble)[theEvent deltaY];
+        }
+        
         //XXX: check for equality for doubles???
         if (rotationX == 0.0 && rotationY == 0.0)
         {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -455,6 +455,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     jdouble rotationY = 0.0;
     if (type == com_sun_glass_events_MouseEvent_WHEEL)
     {
+        // JDK-8183399, JDK-8218424
         if ([theEvent hasPreciseScrollingDeltas])
         {
             rotationX = (jdouble)[theEvent scrollingDeltaX] * 0.1;


### PR DESCRIPTION
Use `hasPreciseScrollingDeltas` to find out if the scroll event comes from a trackpad (or some mice), that provides much more precise delta, or from a generic scroll wheel, that issues rather coarse scroll deltas. 