### PR TITLE
JDK-8218611: [DRT] fast/xslt tests fails with Unsupported encoding windows-1251

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -282,7 +282,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * Whether icu support is available
  */
-#if 0
+#if 1
 #define LIBXML_ICU_ENABLED
 #endif
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -524,4 +524,20 @@ public class MiscellaneousTest extends TestBase {
                     "  </body>\n" +
                     "</html>");
     }
+
+    @Test public void testWindows1251EncodingWithXML() {
+        final String xmlStr = "<?xml version='1.0' encoding='windows-1251'?><TEST id='test'/>";
+        loadContent(
+            "<script>\n" +
+            "const text = '<?xml version=\"1.0\" encoding=\"windows-1251\"?><test/>';\n" +
+            "const parser = new DOMParser();\n" +
+            "window.xmlDoc = parser.parseFromString(text, 'text/xml');\n" +
+            "</script>"
+        );
+        submit(() -> {
+            // WebKit injects error message into body incase of encoding error, otherwise
+            // body should be null.
+            assertNull(getEngine().executeScript("window.xmlDoc.body"));
+        });
+    }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -526,7 +526,6 @@ public class MiscellaneousTest extends TestBase {
     }
 
     @Test public void testWindows1251EncodingWithXML() {
-        final String xmlStr = "<?xml version='1.0' encoding='windows-1251'?><TEST id='test'/>";
         loadContent(
             "<script>\n" +
             "const text = '<?xml version=\"1.0\" encoding=\"windows-1251\"?><test/>';\n" +


### PR DESCRIPTION
Linked JBS: https://bugs.openjdk.java.net/browse/JDK-8218611