### PR TITLE
JDK-8219917: [WebView] Sub-resource integrity check fails

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WCMessageDigestImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WCMessageDigestImpl.java
@@ -31,7 +31,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class WCMessageDigestImpl extends WCMessageDigest {
-    final private MessageDigest digest;
+    private final MessageDigest digest;
 
     public WCMessageDigestImpl(String algorithm) throws NoSuchAlgorithmException {
         digest = MessageDigest.getInstance(algorithm);

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WCMessageDigestImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WCMessageDigestImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.webkit;
+
+import com.sun.webkit.security.WCMessageDigest;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class WCMessageDigestImpl extends WCMessageDigest {
+    final private MessageDigest digest;
+
+    public WCMessageDigestImpl(String algorithm) throws NoSuchAlgorithmException {
+        digest = MessageDigest.getInstance(algorithm);
+    }
+
+    @Override
+    public void addBytes(ByteBuffer input) {
+        digest.update(input);
+    }
+
+    @Override
+    public byte[] computeHash() {
+        return digest.digest();
+    }
+}

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCMessageDigestPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCMessageDigestPerfLogger.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.perf;
+
+import com.sun.javafx.logging.PlatformLogger;
+import com.sun.webkit.security.WCMessageDigest;
+import java.nio.ByteBuffer;
+
+public class WCMessageDigestPerfLogger extends WCMessageDigest {
+    private static final PlatformLogger log =
+            PlatformLogger.getLogger(WCMessageDigestPerfLogger.class.getName());
+
+    private static final PerfLogger logger = PerfLogger.getLogger(log);
+
+    final private WCMessageDigest digest;
+
+    public WCMessageDigestPerfLogger(WCMessageDigest digest) {
+        this.digest = digest;
+    }
+
+    public synchronized static boolean isEnabled() {
+        return logger.isEnabled();
+    }
+
+    @Override
+    public void addBytes(ByteBuffer input) {
+        logger.resumeCount("ADDBYTES");
+        digest.addBytes(input);
+        logger.suspendCount("ADDBYTES");
+    }
+
+    @Override
+    public byte[] computeHash() {
+        logger.resumeCount("COMPUTEHASH");
+        byte[] result = digest.computeHash();
+        logger.suspendCount("COMPUTEHASH");
+        return result;
+    }
+}

--- a/modules/javafx.web/src/main/java/com/sun/webkit/security/WCMessageDigest.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/security/WCMessageDigest.java
@@ -30,6 +30,10 @@ import com.sun.webkit.perf.WCMessageDigestPerfLogger;
 import java.nio.ByteBuffer;
 
 public abstract class WCMessageDigest {
+    /**
+     * Creates the instance of WCMessageDigest for the given algorithm.
+     * @param algorithm the name of the algorithm like SHA-1, SHA-256.
+     */
     protected static WCMessageDigest getInstance(String algorithm) {
         try {
             WCMessageDigest digest = new WCMessageDigestImpl(algorithm);
@@ -39,6 +43,13 @@ public abstract class WCMessageDigest {
         }
     }
 
+    /**
+     * Update the digest using the specified ByteBuffer.
+     */
     public abstract void addBytes(ByteBuffer input);
+
+    /**
+     * Returns the computed hash value.
+     */
     public abstract byte[] computeHash();
 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/security/WCMessageDigest.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/security/WCMessageDigest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.security;
+
+import com.sun.javafx.webkit.WCMessageDigestImpl;
+import com.sun.webkit.perf.WCMessageDigestPerfLogger;
+import java.nio.ByteBuffer;
+
+public abstract class WCMessageDigest {
+    protected static WCMessageDigest getInstance(String algorithm) {
+        try {
+            WCMessageDigest digest = new WCMessageDigestImpl(algorithm);
+            return WCMessageDigestPerfLogger.isEnabled() ? new WCMessageDigestPerfLogger(digest) : digest;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    public abstract void addBytes(ByteBuffer input);
+    public abstract byte[] computeHash();
+}

--- a/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/PlatformJava.cmake
@@ -9,15 +9,9 @@ list(APPEND PAL_INCLUDE_DIRECTORIES
     "${ICU_INCLUDE_DIRS}"
 )
 
-if (APPLE)
-    list(APPEND PAL_SOURCES
-        crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
-    )
-else ()
-    list(APPEND PAL_SOURCES
-        crypto/java/CryptoDigestJava.cpp
-    )
-endif ()
+list(APPEND PAL_SOURCES
+    crypto/java/CryptoDigestJava.cpp
+)
 
 add_definitions(-DSTATICALLY_LINKED_WITH_JavaScriptCore)
 add_definitions(-DSTATICALLY_LINKED_WITH_WTF)

--- a/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/crypto/java/CryptoDigestJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/crypto/java/CryptoDigestJava.cpp
@@ -66,7 +66,7 @@ jstring toJavaMessageDigestAlgorithm(CryptoDigest::Algorithm algorithm)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     const char* algorithmStr = "";
-    switch(algorithm) {
+    switch (algorithm) {
         case CryptoDigest::Algorithm::SHA_1:
             algorithmStr = "SHA-1";
             break;
@@ -87,8 +87,6 @@ jstring toJavaMessageDigestAlgorithm(CryptoDigest::Algorithm algorithm)
 }
 
 } // namespace CryptoDigestInternal
-
-jclass PG_GetWebPageClass(JNIEnv* env);
 
 struct CryptoDigestContext {
     JGObject jDigest { };
@@ -116,7 +114,7 @@ void CryptoDigest::addBytes(const void* input, size_t length)
     using namespace CryptoDigestInternal;
 
     JNIEnv* env = WebCore_GetJavaEnv();
-    if(!m_context->jDigest || !env) {
+    if (!m_context->jDigest || !env) {
         return;
     }
 
@@ -133,7 +131,7 @@ Vector<uint8_t> CryptoDigest::computeHash()
     using namespace CryptoDigestInternal;
 
     JNIEnv* env = WebCore_GetJavaEnv();
-    if(!m_context->jDigest || !env) {
+    if (!m_context->jDigest || !env) {
         return { };
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/crypto/java/CryptoDigestJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PAL/pal/crypto/java/CryptoDigestJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,39 +26,133 @@
 #include "config.h"
 
 #include "CryptoDigest.h"
-#include "Logging.h"
-
-#define notImplemented()
+#include <jni.h>
+#include <wtf/java/JavaEnv.h>
+#include <wtf/java/JavaRef.h>
 
 namespace PAL {
 
-struct CryptoDigestContext { };
+namespace CryptoDigestInternal {
+
+inline jclass GetMessageDigestClass(JNIEnv* env)
+{
+    static JGClass messageDigestCls(
+        env->FindClass("com/sun/webkit/security/WCMessageDigest"));
+    ASSERT(messageDigestCls);
+    return messageDigestCls;
+}
+
+inline JLObject GetMessageDigestInstance(jstring algorithm)
+{
+    JNIEnv* env = WebCore_GetJavaEnv();
+    if (!env) {
+        return { };
+    }
+
+    static jmethodID midGetInstance = env->GetStaticMethodID(
+        GetMessageDigestClass(env),
+        "getInstance",
+        "(Ljava/lang/String;)Lcom/sun/webkit/security/WCMessageDigest;");
+    ASSERT(midGetInstance);
+    JLObject jDigest = env->CallStaticObjectMethod(GetMessageDigestClass(env), midGetInstance, algorithm);
+    if (CheckAndClearException(env)) {
+        return { };
+    }
+    return jDigest;
+}
+
+jstring toJavaMessageDigestAlgorithm(CryptoDigest::Algorithm algorithm)
+{
+    JNIEnv* env = WebCore_GetJavaEnv();
+
+    const char* algorithmStr = "";
+    switch(algorithm) {
+        case CryptoDigest::Algorithm::SHA_1:
+            algorithmStr = "SHA-1";
+            break;
+        case CryptoDigest::Algorithm::SHA_224:
+            algorithmStr = "SHA-224";
+            break;
+        case CryptoDigest::Algorithm::SHA_256:
+            algorithmStr = "SHA-256";
+            break;
+        case CryptoDigest::Algorithm::SHA_384:
+            algorithmStr = "SHA-384";
+            break;
+        case CryptoDigest::Algorithm::SHA_512:
+            algorithmStr = "SHA-512";
+            break;
+    }
+    return env->NewStringUTF(algorithmStr);
+}
+
+} // namespace CryptoDigestInternal
+
+jclass PG_GetWebPageClass(JNIEnv* env);
+
+struct CryptoDigestContext {
+    JGObject jDigest { };
+};
 
 CryptoDigest::CryptoDigest()
+    : m_context(new CryptoDigestContext)
 {
-    notImplemented();
 }
 
 CryptoDigest::~CryptoDigest()
 {
-    notImplemented();
 }
 
-std::unique_ptr<CryptoDigest> CryptoDigest::create(CryptoDigest::Algorithm)
+std::unique_ptr<CryptoDigest> CryptoDigest::create(CryptoDigest::Algorithm algorithm)
 {
-    notImplemented();
-    return std::unique_ptr<CryptoDigest>(new CryptoDigest);
+    using namespace CryptoDigestInternal;
+    auto digest = std::unique_ptr<CryptoDigest>(new CryptoDigest);
+    digest->m_context->jDigest = GetMessageDigestInstance(toJavaMessageDigestAlgorithm(algorithm));
+    return digest;
 }
 
-void CryptoDigest::addBytes(const void*, size_t)
+void CryptoDigest::addBytes(const void* input, size_t length)
 {
-    notImplemented();
+    using namespace CryptoDigestInternal;
+
+    JNIEnv* env = WebCore_GetJavaEnv();
+    if(!m_context->jDigest || !env) {
+        return;
+    }
+
+    static jmethodID midUpdate = env->GetMethodID(
+        GetMessageDigestClass(env),
+        "addBytes",
+        "(Ljava/nio/ByteBuffer;)V");
+    ASSERT(midUpdate);
+    env->CallVoidMethod(jobject(m_context->jDigest), midUpdate, env->NewDirectByteBuffer(const_cast<void*>(input), length));
 }
 
 Vector<uint8_t> CryptoDigest::computeHash()
 {
-    notImplemented();
-    return {};
+    using namespace CryptoDigestInternal;
+
+    JNIEnv* env = WebCore_GetJavaEnv();
+    if(!m_context->jDigest || !env) {
+        return { };
+    }
+
+    static jmethodID midDigest = env->GetMethodID(
+        GetMessageDigestClass(env),
+        "computeHash",
+        "()[B");
+    ASSERT(midUpdate);
+
+    JLocalRef<jbyteArray> jDigestBytes = static_cast<jbyteArray>(env->CallObjectMethod(jobject(m_context->jDigest), midDigest));
+    void* digest = env->GetPrimitiveArrayCritical(static_cast<jbyteArray>(jDigestBytes), 0);
+    if (!digest) {
+        return { };
+    }
+
+    Vector<uint8_t> result;
+    result.append(static_cast<uint8_t*>(digest), env->GetArrayLength(jDigestBytes));
+    env->ReleasePrimitiveArrayCritical(jDigestBytes, digest, 0);
+    return result;
 }
 
 } // namespace PAL

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/SubresourceIntegrityTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/SubresourceIntegrityTest.java
@@ -38,49 +38,52 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
 public final class SubresourceIntegrityTest extends TestBase {
 
     // To arguments from junit data provider.
     private final String hashValue;
-    private final String algorithm;
+    private final String expected;
     private File htmlFile;
-    // Only sha256, sha384, sha512 are supported
-    // Ref. https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#Using_Subresource_Integrity
-    private static Set<String> ALLOWED_HASH_ALGOS = Set.of("sha256", "sha384", "sha512");
-
+    // Expectations
+    private final static String LOADED = "hello";
+    private final static String NOT_LOADED = "not loaded";
     // TODO: junit 4.11 provides an option to label arguments.
     @Parameters
     public static Collection<String[]> data() {
         return Arrays.asList(new String[][] {
             // shasum -b -a 1 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
-            {"sha1-/kpzvnGzRkcE9OFn5j8qRE61nZY="},
+            {"sha1-/kpzvnGzRkcE9OFn5j8qRE61nZY=", LOADED},
             // shasum -b -a 224 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
-            {"sha224-zgiBbbuKJixMVEkaOXnvpSYZGsx7SbSZ0QOckg=="},
+            {"sha224-zgiBbbuKJixMVEkaOXnvpSYZGsx7SbSZ0QOckg==", LOADED},
             // shasum -b -a 256 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
-            {"sha256-vcl3cFaIDAtcQBkUZFdY+tW/bjrg6vX1R+hQ8uB5tHc="},
+            {"sha256-vcl3cFaIDAtcQBkUZFdY+tW/bjrg6vX1R+hQ8uB5tHc=", LOADED},
             // shasum -b -a 384 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
-            {"sha384-+GrI+cacF05VlQitRghQhs1by9CSIyc8XgZTbymUg2oA0EYdLiPMtilnFP3LDbkY"},
+            {"sha384-+GrI+cacF05VlQitRghQhs1by9CSIyc8XgZTbymUg2oA0EYdLiPMtilnFP3LDbkY", LOADED},
             // shasum -b -a 512 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
-            {"sha512-V8m3j61x5soaVcO83NuHavY7Yn4MQYoUgrqJe38f6QYG9QzzgWbVDB1SrZsZ2CVR1IsOnV2MLhnDaZhWOwHDsw=="},
-            // SubresourceIntegrity is not tested for sha1 and sha224
-            {"sha1-0000000000000000000000000000"},
-            {"sha224-0000000000000000000000000000000000000000"},
+            {"sha512-V8m3j61x5soaVcO83NuHavY7Yn4MQYoUgrqJe38f6QYG9QzzgWbVDB1SrZsZ2CVR1IsOnV2MLhnDaZhWOwHDsw==", LOADED},
+            // Only sha256, sha384, sha512 are validated, rest will be ignored and loaded
+            // Ref. https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#Using_Subresource_Integrity
+            {"sha1-0000000000000000000000000000", LOADED},
+            {"sha224-0000000000000000000000000000000000000000", LOADED},
+            // negative tests, change the hash value and ensure it fails
+            {"sha256-Vcl3cFaIDAtcQBkUZFdY+tW/bjrg6vX1R+hQ8uB5tHc=", NOT_LOADED},
+            {"sha384-+grI+cacF05VlQitRghQhs1by9CSIyc8XgZTbymUg2oA0EYdLiPMtilnFP3LDbkY", NOT_LOADED},
+            {"sha512-v8m3j61x5soaVcO83NuHavY7Yn4MQYoUgrqJe38f6QYG9QzzgWbVDB1SrZsZ2CVR1IsOnV2MLhnDaZhWOwHDsw==", NOT_LOADED},
+            // should load for invalid hash algorithm
+            {"unknown-0000", LOADED},
+            {"", LOADED},
         });
     }
 
-    private static boolean allowed(final String algorithm) {
-        return ALLOWED_HASH_ALGOS.contains(algorithm);
-    }
-
-    public SubresourceIntegrityTest(final String hashValue) {
+    public SubresourceIntegrityTest(final String hashValue, final String expected) {
         this.hashValue = hashValue;
-        this.algorithm = hashValue.substring(0, hashValue.indexOf('-'));
+        this.expected = expected;
     }
 
-    public void setup(final String hashValue) throws Exception {
+    @Before
+    public void setup() throws Exception {
         // loadContent won't work with CORS, use file:// for main resource.
         htmlFile = new File("subresource-integrity-test.html");
         final FileOutputStream out = new FileOutputStream(htmlFile);
@@ -89,36 +92,23 @@ public final class SubresourceIntegrityTest extends TestBase {
         final String html =
                 String.format("<html>\n" +
                 "<head><script src='%s' integrity='%s' crossorigin='anonymous'></script></head>\n" +
-                "</html>", scriptUrl, hashValue);
+                "<body>%s</body>\n" +
+                "</html>", scriptUrl, hashValue, NOT_LOADED);
         out.write(html.getBytes());
         out.close();
     }
 
     @Test
-    public void testScriptTagWithCorrectHashValue() throws Exception {
-        setup(hashValue);
+    public void testScriptTagWithCorrectHashValue() {
         load(htmlFile);
         final String bodyText = (String) executeScript("document.body.innerText");
-        assertNotNull("document.body.innerText must be non null for " + algorithm, bodyText);
-        assertEquals("hello text must be added to body if script loaded successfully for " + algorithm, "hello", bodyText);
-    }
-
-    @Test
-    public void testScriptTagWithIncorrectHashValue() throws Exception {
-        // SubresourceIntegrity is not tested for sha1 and sha224.
-        assumeTrue(allowed(algorithm));
-        // corrupt the hash value to check the negative case
-        char c = hashValue.charAt(20);
-        setup(hashValue.replace(c, (char) (c + 1)));
-        load(htmlFile);
-        final String bodyText = (String) executeScript("document.body.innerText");
-        assertNotNull("document.body.innerText must be non null for" + algorithm, bodyText);
-        assertEquals("body text should be empty for " + algorithm, "", bodyText);
+        assertNotNull("document.body.innerText must be non null for " + hashValue, bodyText);
+        assertEquals(hashValue, expected, bodyText);
     }
 
     @After
     public void tearDown() {
-        if (htmlFile != null && !htmlFile.delete()) {
+        if (!htmlFile.delete()) {
             htmlFile.deleteOnExit();
         }
     }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/SubresourceIntegrityTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/SubresourceIntegrityTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Parameterized.class)
+public final class SubresourceIntegrityTest extends TestBase {
+
+    // To arguments from junit data provider.
+    private final String hashValue;
+    private File htmlFile;
+
+    // TODO: junit 4.11 provides an option to label arguments.
+    @Parameters
+    public static Collection<String[]> data() {
+        return Arrays.asList(new String[][] {
+            // shasum -b -a 1 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
+            {"sha1-/kpzvnGzRkcE9OFn5j8qRE61nZY="},
+            // shasum -b -a 224 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
+            {"sha224-zgiBbbuKJixMVEkaOXnvpSYZGsx7SbSZ0QOckg=="},
+            // shasum -b -a 256 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
+            {"sha256-vcl3cFaIDAtcQBkUZFdY+tW/bjrg6vX1R+hQ8uB5tHc="},
+            // shasum -b -a 384 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
+            {"sha384-+GrI+cacF05VlQitRghQhs1by9CSIyc8XgZTbymUg2oA0EYdLiPMtilnFP3LDbkY"},
+            // shasum -b -a 512 subresource-integrity-test.js | awk '{ print $1 }' | xxd -r -p | base64
+            {"sha512-V8m3j61x5soaVcO83NuHavY7Yn4MQYoUgrqJe38f6QYG9QzzgWbVDB1SrZsZ2CVR1IsOnV2MLhnDaZhWOwHDsw=="},
+        });
+    }
+
+    public SubresourceIntegrityTest(final String hashValue) {
+        this.hashValue = hashValue;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        // loadContent won't work with CORS, use file:// for main resource.
+        htmlFile = new File("subresource-integrity-test.html");
+        final FileOutputStream out = new FileOutputStream(htmlFile);
+        final String scriptUrl =
+                new File("src/test/resources/test/html/subresource-integrity-test.js").toURI().toASCIIString();
+        final String html =
+                String.format("<html>\n" +
+                "<head><script src='%s' integrity='%s' crossorigin='anonymous'></script></head>\n" +
+                "</html>", scriptUrl, hashValue);
+        out.write(html.getBytes());
+        out.close();
+    }
+
+    @Test
+    public void testUsingScriptTag() {
+        load(htmlFile);
+        final String bodyText = (String) executeScript("document.body.innerText");
+        assertNotNull("document.body.innerText must be non null", bodyText);
+        assertEquals("hello text must be added to body if script loaded successfully", "hello", bodyText);
+    }
+
+    @After
+    public void tearDown() {
+        if (!htmlFile.delete()) {
+            htmlFile.deleteOnExit();
+        }
+    }
+}
+

--- a/modules/javafx.web/src/test/resources/test/html/subresource-integrity-test.js
+++ b/modules/javafx.web/src/test/resources/test/html/subresource-integrity-test.js
@@ -1,0 +1,3 @@
+window.onload = () => {
+    document.body.innerText = "hello";
+}


### PR DESCRIPTION
Currently [subresource integrity check](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is not working in Linux and Windows due to missing implementation of `PAL::CryptoDigest` on those platforms. However it works in macOS because we rely on CommonCrypto based CryptoDigest implementation from WebCore. 

The goal of this PR is to implement `PAL::CryptoDigest` using `java.security.MessageDigest`., so that the subresource integrity can be supported across all the platforms.

After this, `PAL::CryptoDigest` will make use of `java.security.MessageDigest` based implementation on all platforms.

JBS link: https://bugs.openjdk.java.net/browse/JDK-8219917

This PR will fix #230.