### PR TITLE
8089986: Removed beeping when alt+key is pressed on Windows

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -544,6 +544,9 @@ LRESULT GlassWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_CAPTURECHANGED:
             ViewContainer::NotifyCaptureChanged(GetHWND(), (HWND)lParam);
             break;
+        case WM_MENUCHAR:
+            // Stop the beep when missing mnemonic or accelerator key JDK-8089986
+            return MNC_CLOSE << 16;
         case WM_SYSKEYDOWN:
         case WM_SYSKEYUP:
         case WM_KEYDOWN:


### PR DESCRIPTION
On Windows, a beep sound always plays when using accelerators/mnemonics with the alt key, even if those accelerators exist. It's only supposed to beep when no such key combination is registered (alt+L vs alt+F for example)

I've found a solution which never beeps which I believe is preferable. https://github.com/DeanWookey/openjdk-jfx/commit/3f8520e22f5090a35097005254133f2eac8f97cc, based on this stack overflow post: https://stackoverflow.com/questions/3662192/disable-messagebeep-on-invalid-syskeypress

Javafx on windows doesn't support the windows system menu, as seen in WinApplication which doesn't override the _supportsSystemMenu() method and returns false. The f10 and alt+f10 events are also prevented from being processed by Windows. 

`                if (wParam == VK_MENU || (wParam == VK_F10 && !GetModifiers())) {
                    // Disable activation of the window's system menu
                    return 0;
                }
`

Hence we should be safe to respond to the WM_MENUCHAR message by closing the system menu which doesn't beep ever. 

We could try make it beep when alt+key is not consumed. Applications like Chrome don't do this, but I think it could be done.