### PR TITLE
8088717: Taskbar iconification of undecorated windows in Windows

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -160,6 +160,11 @@ public abstract class Window {
      */
     @Native public static final int UNIFIED = 1 << 8;
 
+    /**
+     * Indicates that the window is modal which affects whether the window is minimizable.
+     */
+    @Native public static final int MODAL = 1 << 9;
+
     final static public class State {
         @Native public static final int NORMAL = 1;
         @Native public static final int MINIMIZED = 2;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -194,6 +194,9 @@ class WindowStage extends GlassStage {
                             break;
                     }
                 }
+                if (modality != Modality.NONE) {
+                    windowMask |= Window.MODAL;
+                }
                 platformWindow =
                         app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
                 platformWindow.setResizable(resizable);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1245,6 +1245,10 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_win_WinWindow__1createWindow
         } else {
             dwExStyle = 0;
             dwStyle |= WS_POPUP;
+            // if undecorated or transparent and not modal, enable taskbar iconification toggling
+            if (!(mask & com_sun_glass_ui_Window_MODAL)) {
+                dwStyle |= WS_MINIMIZEBOX;
+            }
         }
 
         if (mask & com_sun_glass_ui_Window_TRANSPARENT) {


### PR DESCRIPTION
Related bug reports:
https://bugs.openjdk.java.net/browse/JDK-8089296, https://bugs.openjdk.java.net/browse/JDK-8088717, https://bugs.openjdk.java.net/browse/JDK-8134658, possibly https://bugs.openjdk.java.net/browse/JDK-8127270

Solution is based off http://stackoverflow.com/questions/26972683/javafx-minimizing-undecorated-stage

I had to add Window.MODAL because we need to know if transparent/undecorated windows should have the ability to minimize/restore by clicking the taskbar. It could've been done by adding  MINIMIZABLE to the mask in WindowStage.java, however without the ability to test that modification on other platforms, the safest thing was to add a new flag. Also, MINIMIZABLE and MAXIMIZABLE and CLOSABLE are derived, and not directly settable. It probably makes sense going forward to expose all the parameters that are settable to the native code so that the decisions on how to display those styles can be made there.

Here is some code to test the iconfication:

```
public class WindowsUndecoratedTest extends Application {
    
    @Override
    public void start(Stage primaryStage) throws InterruptedException {
        BorderPane s = new BorderPane();
        s.setStyle("-fx-background-color:blue");

        primaryStage.setScene(new Scene(s, 600, 600));
        primaryStage.initStyle(StageStyle.UNDECORATED);
        
        primaryStage.show();
        
        Stage secondaryStage = new Stage();
        Pane inner = new Pane();
        inner.setStyle("-fx-background-color:red");
        secondaryStage.setScene(new Scene(inner, 500, 500));
        secondaryStage.initStyle(StageStyle.UNDECORATED);
        //secondaryStage.initModality(Modality.APPLICATION_MODAL);
        secondaryStage.show();
    }
    
    public static void main(String[] args) {
        launch(args);
    }
}
```

What you should see is without the patch, clicking the taskbar button only brings the window to the front whether the window is modal or not. If you iconify the secondaryStage before clicking the taskbar, a weird title bar appears. Similar results for TRANSPARENT.

With the patch, everything works as expected, whether UNDECORATED or TRANSPARENT. When the secondary stage is modal, it can't be iconified by clicking the taskbar, but it will be brought to the front. When not modal, both stages will minimise and restore when their taskbar buttons are clicked.
