### PR TITLE
JDK-8208173: isComplexCharCode() returns false for U+11FF

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
@@ -145,7 +145,7 @@ public class ScriptMapper {
         else if (code < 0x1100) {
             return false;
         }
-        else if (code < 0x11ff) { // U+1100 - U+11FF Old Hangul
+        else if (code <= 0x11ff) { // U+1100 - U+11FF Old Hangul
             return true;
         }
         else if (code < 0x1780) {


### PR DESCRIPTION
Issue is
https://github.com/javafxports/openjdk-jfx/issues/133

Simply equal is missing.

Old Hangul is defined U+1100 to U+11FF.
http://www.unicode.org/charts/PDF/U1100.pdf