### PR TITLE
JDK-8221269: Extract embedded actions from JSL grammar file to Visitor class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2116,7 +2116,6 @@ project(":graphics") {
             "-package",
             "com.sun.scenario.effect.compiler",
             "-visitor",
-            "com/sun/scenario/effect/compiler/JSL.g4",
             inJSL ]
 
         inputs.dir wd

--- a/build.gradle
+++ b/build.gradle
@@ -2115,6 +2115,8 @@ project(":graphics") {
             outDir.toString(),
             "-package",
             "com.sun.scenario.effect.compiler",
+            "-visitor",
+            "com/sun/scenario/effect/compiler/JSL.g4",
             inJSL ]
 
         inputs.dir wd

--- a/modules/javafx.graphics/src/jslc/antlr/com/sun/scenario/effect/compiler/JSL.g4
+++ b/modules/javafx.graphics/src/jslc/antlr/com/sun/scenario/effect/compiler/JSL.g4
@@ -25,36 +25,22 @@
 
 grammar JSL;
 
-@header {
-    import com.sun.scenario.effect.compiler.model.*;
-    import com.sun.scenario.effect.compiler.tree.*;
-}
-
-@members {
-    private SymbolTable symbols = new SymbolTable();
-    private TreeMaker tm = new TreeMaker(symbols);
-
-    public SymbolTable getSymbolTable() {
-        return symbols;
-    }
-}
-
-field_selection returns [String fields]
-        : r=RGBA_FIELDS { $fields = $r.text; }
-        | x=XYZW_FIELDS { $fields = $x.text; }
+field_selection
+        : r=RGBA_FIELDS
+        | x=XYZW_FIELDS
         ;
 
-primary_expression returns [Expr expr]
-        : IDENTIFIER    { $expr = tm.variable($IDENTIFIER.text); }
-        | INTCONSTANT   { $expr = tm.literal(Type.INT, Integer.valueOf($INTCONSTANT.text)); }
-        | FLOATCONSTANT { $expr = tm.literal(Type.FLOAT, Float.valueOf($FLOATCONSTANT.text)); }
-        | BOOLCONSTANT  { $expr = tm.literal(Type.BOOL, Boolean.valueOf($BOOLCONSTANT.text)); }
-        | LEFT_PAREN e=expression RIGHT_PAREN { $expr = tm.parenExpr($e.expr); }
+primary_expression
+        : IDENTIFIER
+        | INTCONSTANT
+        | FLOATCONSTANT
+        | BOOLCONSTANT
+        | LEFT_PAREN e=expression RIGHT_PAREN
         ;
 
-primary_or_call returns [Expr expr]
-        : e=primary_expression { $expr = $e.expr; }
-        | f=function_call      { $expr = $f.expr; }
+primary_or_call
+        : e=primary_expression
+        | f=function_call
         ;
 
 //
@@ -69,19 +55,13 @@ primary_or_call returns [Expr expr]
 // but not things like:
 //   arr[3].r++
 //
-postfix_expression returns [Expr expr]
+postfix_expression
         : e=primary_or_call LEFT_BRACKET ae=expression RIGHT_BRACKET fs=field_selection
-              { $expr = tm.fieldSelect(tm.arrayAccess($e.expr, $ae.expr), $fs.fields); }
         | e=primary_or_call LEFT_BRACKET ae=expression RIGHT_BRACKET
-              { $expr = tm.arrayAccess($e.expr, $ae.expr); }
         | e=primary_or_call fs=field_selection
-              { $expr = tm.fieldSelect($e.expr, $fs.fields); }
         | e=primary_or_call INC
-              { $expr = tm.unary(UnaryOpType.INC, $e.expr); }
         | e=primary_or_call DEC
-              { $expr = tm.unary(UnaryOpType.DEC, $e.expr); }
         | e=primary_or_call
-              { $expr = $e.expr; }
         ;
 
 // From the GLSL spec...
@@ -89,31 +69,24 @@ postfix_expression returns [Expr expr]
 // analysis recognized most of them as keywords.  They are now
 // recognized through "type_specifier".
 
-function_call returns [Expr expr]
+function_call
         : id=IDENTIFIER LEFT_PAREN p=function_call_parameter_list? RIGHT_PAREN
-            {
-                $expr = tm.call($id.text, $p.ctx != null ? $p.exprList : null);
-            }
         | ts=type_specifier LEFT_PAREN p=function_call_parameter_list? RIGHT_PAREN
-            {
-                Type type = Type.fromToken($ts.text);
-                $expr = tm.vectorCtor(type, $p.ctx != null ? $p.exprList : null);
-            }
         ;
 
-function_call_parameter_list returns [List<Expr> exprList = new ArrayList<Expr>()]
-        : a=assignment_expression { $exprList.add($a.expr); }
-          (COMMA a=assignment_expression {$exprList.add($a.expr); }
+function_call_parameter_list
+        : a=assignment_expression
+          (COMMA a=assignment_expression
           )*
         ;
 
-unary_expression returns [Expr expr]
-        : p=postfix_expression     { $expr = $p.expr; }
-        | INC   u=unary_expression { $expr = tm.unary(UnaryOpType.INC,     $u.expr); }
-        | DEC   u=unary_expression { $expr = tm.unary(UnaryOpType.DEC,     $u.expr); }
-        | PLUS  u=unary_expression { $expr = tm.unary(UnaryOpType.PLUS,    $u.expr); }
-        | DASH  u=unary_expression { $expr = tm.unary(UnaryOpType.MINUS,   $u.expr); }
-        | BANG  u=unary_expression { $expr = tm.unary(UnaryOpType.NOT,     $u.expr); }
+unary_expression
+        : p=postfix_expression
+        | INC   u=unary_expression
+        | DEC   u=unary_expression
+        | PLUS  u=unary_expression
+        | DASH  u=unary_expression
+        | BANG  u=unary_expression
         ;
 
 // From the GLSL spec...
@@ -122,52 +95,62 @@ unary_expression returns [Expr expr]
 // From the GLSL spec...
 // Grammar Note:  No '*' or '&' unary ops.  Pointers are not supported.
 
-multiplicative_expression returns [Expr expr]
-        : a=unary_expression { $expr = $a.expr; }
-          (STAR  b=multiplicative_expression { $expr = tm.binary(BinaryOpType.MUL, $expr, $b.expr); }
-          |SLASH b=multiplicative_expression { $expr = tm.binary(BinaryOpType.DIV, $expr, $b.expr); }
-          )*
+multiplicative_operator
+        : STAR
+        | SLASH
         ;
 
-additive_expression returns [Expr expr]
-        : a=multiplicative_expression { $expr = $a.expr; }
-          (PLUS b=multiplicative_expression { $expr = tm.binary(BinaryOpType.ADD, $expr, $b.expr); }
-          |DASH b=multiplicative_expression { $expr = tm.binary(BinaryOpType.SUB, $expr, $b.expr); }
-          )*
+multiplicative_expression
+        : a=unary_expression
+          (c=multiplicative_operator b=multiplicative_expression)*
         ;
 
-relational_expression returns [Expr expr]
-        : a=additive_expression { $expr = $a.expr; }
-          (LTEQ b=additive_expression { $expr = tm.binary(BinaryOpType.LTEQ, $expr, $b.expr); }
-          |GTEQ b=additive_expression { $expr = tm.binary(BinaryOpType.GTEQ, $expr, $b.expr); }
-          |LT   b=additive_expression { $expr = tm.binary(BinaryOpType.LT,   $expr, $b.expr); }
-          |GT   b=additive_expression { $expr = tm.binary(BinaryOpType.GT,   $expr, $b.expr); }
-          )*
+additive_operator
+        : PLUS
+        | DASH
         ;
 
-equality_expression returns [Expr expr]
-        : a=relational_expression { $expr = $a.expr; }
-          (EQEQ b=relational_expression { $expr = tm.binary(BinaryOpType.EQEQ, $expr, $b.expr); }
-          | NEQ b=relational_expression { $expr = tm.binary(BinaryOpType.NEQ,  $expr, $b.expr); }
-          )*
+additive_expression
+        : a=multiplicative_expression
+          (c=additive_operator b=multiplicative_expression)*
         ;
 
-logical_and_expression returns [Expr expr]
-        : a=equality_expression { $expr = $a.expr; }
-          (AND b=equality_expression { $expr = tm.binary(BinaryOpType.AND, $expr, $b.expr); }
-          )*
+relational_operator
+        : LTEQ
+        | GTEQ
+        | LT
+        | GT
         ;
 
-logical_xor_expression returns [Expr expr]
-        : a=logical_and_expression { $expr = $a.expr; }
-          (XOR b=logical_and_expression { $expr = tm.binary(BinaryOpType.XOR, $expr, $b.expr); }
-          )*
+relational_expression
+        : a=additive_expression
+          (c=relational_operator b=additive_expression)*
         ;
 
-logical_or_expression returns [Expr expr]
-        : a=logical_xor_expression { $expr = $a.expr; }
-          (OR b=logical_xor_expression { $expr = tm.binary(BinaryOpType.OR, $expr, $b.expr); }
-          )*
+equality_operator
+        : EQEQ
+        | NEQ
+        ;
+
+equality_expression
+        : a=relational_expression
+          (c=equality_operator b=relational_expression
+          | NEQ b=relational_expression)*
+        ;
+
+logical_and_expression
+        : a=equality_expression
+          (AND b=equality_expression)*
+        ;
+
+logical_xor_expression
+        : a=logical_and_expression
+          (XOR b=logical_and_expression)*
+        ;
+
+logical_or_expression
+        : a=logical_xor_expression
+          (OR b=logical_xor_expression)*
         ;
 
 ternary_part
@@ -175,15 +158,13 @@ ternary_part
         ;
 
 // TODO: handle ternary
-conditional_expression returns [Expr expr]
-        : a=logical_or_expression ternary_part? { $expr = $a.expr; }
+conditional_expression
+        : a=logical_or_expression ternary_part?
         ;
 
-assignment_expression returns [Expr expr]
+assignment_expression
         : a=unary_expression op=assignment_operator b=assignment_expression
-              { $expr = tm.binary(BinaryOpType.forSymbol($op.text), $a.expr, $b.expr); }
         | c=conditional_expression
-              { $expr = $c.expr; }
         ;
 
 assignment_operator
@@ -200,134 +181,46 @@ assignment_operator
 //          (COMMA e=assignment_expression { $exprList.add($e.expr); })*
 //        ;
 
-expression returns [Expr expr]
-        : e=assignment_expression { $expr = $e.expr; }
+expression
+        : e=assignment_expression
         ;
 
-function_prototype returns [Function func]
+function_prototype
         : t=type_specifier id=IDENTIFIER LEFT_PAREN p=parameter_declaration_list? RIGHT_PAREN
-            {
-                Type type = Type.fromToken($t.text);
-                $func = symbols.declareFunction($id.text, type, ($p.ctx != null) ? $p.paramList : null);
-            }
         ;
 
-parameter_declaration returns [Param param]
+parameter_declaration
         : t=type_specifier id=IDENTIFIER
-            {
-                Type type = Type.fromToken($t.text);
-                $param = new Param($id.text, type);
-            }
         ;
 
-parameter_declaration_list returns [List<Param> paramList = new ArrayList<Param>()]
-        : p=parameter_declaration { $paramList.add($p.param); }
-          (COMMA p=parameter_declaration { $paramList.add($p.param); } )*
+parameter_declaration_list
+        : p=parameter_declaration
+          (COMMA p=parameter_declaration)*
         ;
 
-declaration_identifier_and_init returns [String name, Expr arrayInit, Expr init]
-        : id=IDENTIFIER { $name = $id.text; }
-          (LEFT_BRACKET ae=constant_expression { $arrayInit = $ae.expr; } RIGHT_BRACKET)?
-          (EQUAL e=initializer { $init = $e.expr; })?
+declaration_identifier_and_init
+        : id=IDENTIFIER
+          (LEFT_BRACKET ae=constant_expression RIGHT_BRACKET)?
+          (EQUAL e=initializer)?
         ;
 
-single_declaration returns [VarDecl decl]
+single_declaration
         : t=fully_specified_type d=declaration_identifier_and_init
-          {
-              int arraySize = -1;
-              Expr ainit = $d.arrayInit;
-              if (ainit != null) {
-                  if (ainit instanceof LiteralExpr) {
-                      Object val = ((LiteralExpr)ainit).getValue();
-                      if (!(val instanceof Integer)) {
-                          throw new RuntimeException("Array size must be an integer");
-                      }
-                      arraySize = ((Integer)val).intValue();
-                  } else if (ainit instanceof VariableExpr) {
-                      Variable var = ((VariableExpr)ainit).getVariable();
-                      Object val = var.getConstValue();
-                      if (!(val instanceof Integer) || var.getQualifier() != Qualifier.CONST) {
-                          throw new RuntimeException("Array size must be a constant integer");
-                      }
-                      arraySize = ((Integer)val).intValue();
-                  }
-              }
-
-              Object constValue = null;
-              if ($t.qual == Qualifier.CONST) {
-                  Expr cinit = $d.init;
-                  if (cinit == null) {
-                      throw new RuntimeException("Constant value must be initialized");
-                  }
-                  // TODO: for now, allow some basic expressions on the rhs
-                  // of the constant declaration...
-                  //if (!(cinit instanceof LiteralExpr)) {
-                  //    throw new RuntimeException("Constant initializer must be a literal (for now)");
-                  //}
-                  Type ctype = cinit.getResultType();
-                  if (ctype != $t.type) {
-                      throw new RuntimeException("Constant type must match that of initializer");
-                  }
-                  if (cinit instanceof LiteralExpr) {
-                      constValue = ((LiteralExpr)cinit).getValue();
-                  } else {
-                      // TODO: This is gross, but to support complex constant
-                      // initializers (such as "const FOO = BAR / 42.0;") we
-                      // will just save the full text of the rhs and hope that
-                      // the backend does the right thing with it.  The real
-                      // solution obviously would be to evaluate the expression
-                      // now and reduce it to a single value.
-                      constValue = $d.init.toString();
-                  }
-              }
-
-              Variable var =
-                  symbols.declareVariable($d.name,
-                                          $t.type, $t.qual, $t.precision,
-                                          arraySize, constValue);
-              $decl = tm.varDecl(var, $d.init);
-          }
         ;
 
-declaration returns [List<VarDecl> declList = new ArrayList<VarDecl>()]
-        : s=single_declaration { $declList.add($s.decl); }
-          (COMMA d=declaration_identifier_and_init
-          {
-              Variable base = $s.decl.getVariable();
-              Variable var =
-                  symbols.declareVariable($d.name,
-                                          base.getType(),
-                                          base.getQualifier(),
-                                          base.getPrecision());
-              $declList.add(tm.varDecl(var, $d.init));
-          }
-          )* SEMICOLON
+declaration
+        : s=single_declaration
+          (COMMA d=declaration_identifier_and_init)* SEMICOLON
         ;
 
 // From GLSL spec...
 // Grammar Note:  No 'enum', or 'typedef'.
 
-fully_specified_type returns [Qualifier qual, Precision precision, Type type]
+fully_specified_type
         : tq=type_qualifier tp=type_precision ts=type_specifier
-            {
-                $qual = Qualifier.fromToken($tq.text);
-                $precision = Precision.fromToken($tp.text);
-                $type = Type.fromToken($ts.text);
-            }
         | tq=type_qualifier ts=type_specifier
-            {
-                $qual = Qualifier.fromToken($tq.text);
-                $type = Type.fromToken($ts.text);
-            }
         | tp=type_precision ts=type_specifier
-            {
-                $precision = Precision.fromToken($tp.text);
-                $type = Type.fromToken($ts.text);
-            }
         | ts=type_specifier
-            {
-                $type = Type.fromToken($ts.text);
-            }
         ;
 
 type_qualifier
@@ -354,137 +247,113 @@ type_specifier_nonarray
         | VOID
         ;
 
-initializer returns [Expr expr]
-        : e=assignment_expression { $expr = $e.expr; }
+initializer
+        : e=assignment_expression
         ;
 
-declaration_statement returns [Stmt stmt]
-        : d=declaration { $stmt = tm.declStmt($d.declList); }
+declaration_statement
+        : d=declaration
         ;
 
-statement returns [Stmt stmt]
-        : c=compound_statement { $stmt = $c.stmt; }
-        | s=simple_statement   { $stmt = $s.stmt; }
+statement
+        : c=compound_statement
+        | s=simple_statement
         ;
 
 // From GLSL spec...
 // Grammar Note:  No labeled statements; 'goto' is not supported.
 
-simple_statement returns [Stmt stmt]
-        : d=declaration_statement { $stmt = $d.stmt; }
-        | e=expression_statement  { $stmt = $e.stmt; }
-        | s=selection_statement   { $stmt = $s.stmt; }
-        | i=iteration_statement   { $stmt = $i.stmt; }
-        | j=jump_statement        { $stmt = $j.stmt; }
+simple_statement
+        : d=declaration_statement
+        | e=expression_statement
+        | s=selection_statement
+        | i=iteration_statement
+        | j=jump_statement
         ;
 
-compound_statement returns [Stmt stmt]
-@init {
-    List<Stmt> stmtList = new ArrayList<Stmt>();
-}
-        : LEFT_BRACE (s=statement { stmtList.add($s.stmt); })* RIGHT_BRACE
-          { $stmt = tm.compoundStmt(stmtList); }
+compound_statement
+        : LEFT_BRACE (s=statement)* RIGHT_BRACE
         ;
 
-statement_no_new_scope returns [Stmt stmt]
-        : c=compound_statement_no_new_scope { $stmt = $c.stmt; }
-        | s=simple_statement                { $stmt = $s.stmt; }
+statement_no_new_scope
+        : c=compound_statement_no_new_scope
+        | s=simple_statement
         ;
 
-compound_statement_no_new_scope returns [Stmt stmt]
-@init {
-    List<Stmt> stmtList = new ArrayList<Stmt>();
-}
-        : LEFT_BRACE (s=statement { stmtList.add($s.stmt); })* RIGHT_BRACE
-          { $stmt = tm.compoundStmt(stmtList); }
+compound_statement_no_new_scope
+        : LEFT_BRACE (s=statement)* RIGHT_BRACE
         ;
 
-expression_statement returns [Stmt stmt]
-        : SEMICOLON              { $stmt = tm.exprStmt(null); }
-        | e=expression SEMICOLON { $stmt = tm.exprStmt($e.expr); }
+expression_statement
+        : SEMICOLON
+        | e=expression SEMICOLON
         ;
 
-constant_expression returns [Expr expr]
-        : c=conditional_expression { $expr = $c.expr; }
+constant_expression
+        : c=conditional_expression
         ;
 
-selection_statement returns [Stmt stmt]
+selection_statement
         : IF LEFT_PAREN e=expression RIGHT_PAREN a=statement (ELSE b=statement)?
-              { $stmt = tm.selectStmt($e.expr, $a.stmt, ($b.ctx != null) ? $b.stmt : null); }
         ;
 
 // TODO: implement second half?
-condition returns [Expr expr]
-        : e=expression {$expr = $e.expr; }
+condition
+        : e=expression
 //        | fully_specified_type IDENTIFIER EQUAL initializer
         ;
 
-iteration_statement returns [Stmt stmt]
+iteration_statement
         : WHILE LEFT_PAREN c=condition RIGHT_PAREN snns=statement_no_new_scope
-              { $stmt = tm.whileStmt($c.expr, $snns.stmt); }
         | DO s=statement WHILE LEFT_PAREN e=expression RIGHT_PAREN SEMICOLON
-              { $stmt = tm.doWhileStmt($s.stmt, $e.expr); }
         | u=unroll_modifier FOR LEFT_PAREN init=for_init_statement rem=for_rest_statement RIGHT_PAREN snns=statement_no_new_scope
-              { $stmt = tm.forStmt($init.stmt, $rem.cond, $rem.expr, $snns.stmt, $u.max, $u.check); }
         | FOR LEFT_PAREN init=for_init_statement rem=for_rest_statement RIGHT_PAREN snns=statement_no_new_scope
-              { $stmt = tm.forStmt($init.stmt, $rem.cond, $rem.expr, $snns.stmt, -1, -1); }
         ;
 
-unroll_modifier returns [int max, int check]
+unroll_modifier
         : UNROLL LEFT_PAREN m=INTCONSTANT COMMA c=INTCONSTANT RIGHT_PAREN
-              { $max = Integer.valueOf($m.text); $check = Integer.valueOf($c.text); }
         ;
 
-for_init_statement returns [Stmt stmt]
-        : e=expression_statement  { $stmt = $e.stmt; }
-        | d=declaration_statement { $stmt = $d.stmt; }
+for_init_statement
+        : e=expression_statement
+        | d=declaration_statement
         ;
 
-for_rest_statement returns [Expr cond, Expr expr]
-        : c=condition SEMICOLON e=expression? { $cond = $c.expr; if ($e.ctx != null) $expr = $e.expr; }
-        | SEMICOLON e=expression? { if ($e.ctx != null) $expr = $e.expr; }
+for_rest_statement
+        : c=condition SEMICOLON e=expression?
+        | SEMICOLON e=expression?
         ;
 
-jump_statement returns [Stmt stmt]
-        : CONTINUE SEMICOLON            { $stmt = tm.continueStmt(); }
-        | BREAK SEMICOLON               { $stmt = tm.breakStmt(); }
-        | DISCARD SEMICOLON             { $stmt = tm.discardStmt(); }
-        | RETURN SEMICOLON              { $stmt = tm.returnStmt(null); }
-        | RETURN e=expression SEMICOLON { $stmt = tm.returnStmt($e.expr); }
+jump_statement
+        : CONTINUE SEMICOLON
+        | BREAK SEMICOLON
+        | DISCARD SEMICOLON
+        | RETURN SEMICOLON
+        | RETURN e=expression SEMICOLON
         ;
 
 // From GLSL spec...
 // Grammar Note:  No 'goto'.  Gotos are not supported.
 
-translation_unit returns [ProgramUnit prog]
-@init {
-    List<ExtDecl> declList = new ArrayList<ExtDecl>();
-}
-        : (e=external_declaration { declList.addAll($e.res); } )+
-            { $prog = tm.programUnit(declList); }
+translation_unit
+        : (e=external_declaration)+
         ;
 
-external_declaration returns [List<ExtDecl> res = new ArrayList<ExtDecl>()]
-        : f=function_definition { $res.add($f.def); }
-        | d=declaration         { $res.addAll($d.declList); }
-        | g=glue_block          { $res.add($g.block); }
+external_declaration
+        : f=function_definition
+        | d=declaration
+        | g=glue_block
         ;
 
 // From GLSL spec...
 // Grammar Note:  No 'switch'.  Switch statements not supported.
 
-function_definition returns [FuncDef def]
-@init {
-	symbols.enterFrame();
-}
-        : p=function_prototype s=compound_statement_no_new_scope { $def = tm.funcDef($p.func, $s.stmt); }
+function_definition
+        : p=function_prototype s=compound_statement_no_new_scope
         ;
-finally {
-        symbols.exitFrame();
-}
 
-glue_block returns [GlueBlock block]
-        : g=GLUE_BLOCK { $block = tm.glueBlock($g.text.substring(2, $g.text.length()-2)); }
+glue_block
+        : g=GLUE_BLOCK
         ;
 
 STAR : '*';

--- a/modules/javafx.graphics/src/jslc/antlr/com/sun/scenario/effect/compiler/JSL.g4
+++ b/modules/javafx.graphics/src/jslc/antlr/com/sun/scenario/effect/compiler/JSL.g4
@@ -134,8 +134,7 @@ equality_operator
 
 equality_expression
         : a=relational_expression
-          (c=equality_operator b=relational_expression
-          | NEQ b=relational_expression)*
+          (c=equality_operator b=relational_expression)*
         ;
 
 logical_and_expression

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import com.sun.scenario.effect.compiler.backend.prism.PrismBackend;
 import com.sun.scenario.effect.compiler.backend.sw.java.JSWBackend;
 import com.sun.scenario.effect.compiler.backend.sw.me.MEBackend;
 import com.sun.scenario.effect.compiler.backend.sw.sse.SSEBackend;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -38,7 +39,12 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupDir;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,10 +89,12 @@ public class JSLC {
 
     public static class ParserInfo {
         public JSLParser parser;
+        public JSLVisitor visitor;
         public ProgramUnit program;
 
-        public ParserInfo(JSLParser parser, ProgramUnit program) {
+        public ParserInfo(JSLParser parser, JSLVisitor visitor, ProgramUnit program) {
             this.parser = parser;
+            this.visitor = visitor;
             this.program = program;
         }
     }
@@ -97,8 +105,9 @@ public class JSLC {
 
     public static ParserInfo getParserInfo(InputStream stream) throws Exception {
         JSLParser parser = parse(stream);
-        ProgramUnit program = parser.translation_unit().prog;
-        return new ParserInfo(parser, program);
+        JSLVisitor visitor = new JSLVisitor();
+        ProgramUnit program = visitor.visitTranslation_unit(parser.translation_unit());
+        return new ParserInfo(parser, visitor, program);
     }
 
     /**
@@ -199,7 +208,8 @@ public class JSLC {
             File outFile = jslcinfo.getOutputFile(OUT_D3D);
             if (jslcinfo.force || outOfDate(outFile, sourceTime)) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                HLSLBackend hlslBackend = new HLSLBackend(pinfo.parser, pinfo.program);
+                HLSLBackend hlslBackend = new HLSLBackend(pinfo.parser, pinfo.visitor);
+                hlslBackend.scan(pinfo.program);
                 write(hlslBackend.getShader(), outFile);
             }
         }
@@ -208,7 +218,8 @@ public class JSLC {
             File outFile = jslcinfo.getOutputFile(OUT_ES2);
             if (jslcinfo.force || outOfDate(outFile, sourceTime)) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                ES2Backend es2Backend = new ES2Backend(pinfo.parser, pinfo.program);
+                ES2Backend es2Backend = new ES2Backend(pinfo.parser, pinfo.visitor);
+                es2Backend.scan(pinfo.program);
                 write(es2Backend.getShader(), outFile);
             }
         }
@@ -217,7 +228,7 @@ public class JSLC {
             File outFile = jslcinfo.getOutputFile(OUT_JAVA);
             if (jslcinfo.force || outOfDate(outFile, sourceTime)) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                JSWBackend javaBackend = new JSWBackend(pinfo.parser, pinfo.program);
+                JSWBackend javaBackend = new JSWBackend(pinfo.parser, pinfo.visitor, pinfo.program);
                 String genCode = javaBackend.getGenCode(shaderName, peerName, genericsName, interfaceName);
                 write(genCode, outFile);
             }
@@ -233,7 +244,7 @@ public class JSLC {
             boolean genCFileStale = outOfDate(genCFile, sourceTime);
             if (jslcinfo.force || outFileStale || genCFileStale) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                SSEBackend sseBackend = new SSEBackend(pinfo.parser, pinfo.program);
+                SSEBackend sseBackend = new SSEBackend(pinfo.parser, pinfo.visitor, pinfo.program);
                 SSEBackend.GenCode gen =
                     sseBackend.getGenCode(shaderName, peerName, genericsName, interfaceName);
 
@@ -259,9 +270,9 @@ public class JSLC {
             boolean genCFileStale = outOfDate(genCFile, sourceTime);
             if (jslcinfo.force || outFileStale || genCFileStale) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                MEBackend sseBackend = new MEBackend(pinfo.parser, pinfo.program);
+                MEBackend meBackend = new MEBackend(pinfo.parser, pinfo.visitor, pinfo.program);
                 MEBackend.GenCode gen =
-                    sseBackend.getGenCode(shaderName, peerName, genericsName, interfaceName);
+                    meBackend.getGenCode(shaderName, peerName, genericsName, interfaceName);
 
                 // write impl class
                 if (outFileStale) {
@@ -279,7 +290,7 @@ public class JSLC {
             File outFile = jslcinfo.getOutputFile(OUT_PRISM);
             if (jslcinfo.force || outOfDate(outFile, sourceTime)) {
                 if (pinfo == null) pinfo = getParserInfo(stream);
-                PrismBackend prismBackend = new PrismBackend(pinfo.parser, pinfo.program);
+                PrismBackend prismBackend = new PrismBackend(pinfo.parser, pinfo.visitor, pinfo.program);
                 String genCode = prismBackend.getGlueCode(shaderName, peerName, genericsName, interfaceName);
                 write(genCode, outFile);
             }
@@ -289,10 +300,7 @@ public class JSLC {
     }
 
     public static boolean outOfDate(File outFile, long sourceTime) {
-        if (sourceTime < outFile.lastModified()) {
-            return false;
-        }
-        return true;
+        return sourceTime >= outFile.lastModified();
     }
 
     public static void write(String str, File outFile) throws Exception {
@@ -300,15 +308,9 @@ public class JSLC {
         if (!outDir.exists()) {
             outDir.mkdirs();
         }
-        FileWriter fw = null;
-        try {
-            fw = new FileWriter(outFile);
+        try (FileWriter fw = new FileWriter(outFile)) {
             fw.write(str);
             fw.flush();
-        } finally {
-            if (fw != null) {
-                fw.close();
-            }
         }
     }
 

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/ES2Backend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/ES2Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,15 @@ import java.util.Map;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Precision;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 
 /**
  */
 public class ES2Backend extends GLSLBackend {
 
-    public ES2Backend(JSLParser parser, ProgramUnit program) {
-        super(parser, program);
+    public ES2Backend(JSLParser parser, JSLVisitor visitor) {
+        super(parser, visitor);
     }
 
     // GLSL v1.10 no longer has gl_TexCoord*; these are now passed in

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/ES2Backend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/ES2Backend.java
@@ -31,7 +31,6 @@ import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Precision;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
 import com.sun.scenario.effect.compiler.tree.JSLVisitor;
-import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 
 /**
  */

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/GLSLBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/GLSLBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,15 @@ import java.util.Map;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 
 /**
  */
 public class GLSLBackend extends SLBackend {
 
-    public GLSLBackend(JSLParser parser, ProgramUnit program) {
-        super(parser, program);
+    public GLSLBackend(JSLParser parser, JSLVisitor visitor) {
+        super(parser, visitor);
     }
 
     private static final Map<String, String> qualMap = new HashMap<String, String>();

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/GLSLBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/GLSLBackend.java
@@ -31,7 +31,6 @@ import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.tree.JSLVisitor;
-import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 
 /**
  */

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/HLSLBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/HLSLBackend.java
@@ -36,7 +36,6 @@ import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.Expr;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
 import com.sun.scenario.effect.compiler.tree.JSLVisitor;
-import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.VarDecl;
 
 /**

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/HLSLBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/HLSLBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.Expr;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.VarDecl;
 
@@ -42,8 +43,8 @@ import com.sun.scenario.effect.compiler.tree.VarDecl;
  */
 public class HLSLBackend extends SLBackend {
 
-    public HLSLBackend(JSLParser parser, ProgramUnit program) {
-        super(parser, program);
+    public HLSLBackend(JSLParser parser, JSLVisitor visitor) {
+        super(parser, visitor);
     }
 
     private static final Map<String, String> qualMap = new HashMap<String, String>();

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/SLBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/hw/SLBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import com.sun.scenario.effect.compiler.tree.ExprStmt;
 import com.sun.scenario.effect.compiler.tree.FieldSelectExpr;
 import com.sun.scenario.effect.compiler.tree.ForStmt;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.ParenExpr;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
@@ -65,6 +66,7 @@ import com.sun.scenario.effect.compiler.tree.WhileStmt;
 public abstract class SLBackend extends TreeScanner {
 
     private JSLParser parser;
+    protected JSLVisitor visitor;
     private StringBuilder sb = new StringBuilder();
     private Variable unrollVar = null;
     private int unrollIndex = -1;
@@ -72,9 +74,9 @@ public abstract class SLBackend extends TreeScanner {
     protected boolean isVertexColorReferenced;
     protected int maxTexCoordIndex = -1;
 
-    protected SLBackend(JSLParser parser, ProgramUnit program) {
+    protected SLBackend(JSLParser parser, JSLVisitor visitor) {
         this.parser = parser;
-        scan(program);
+        this.visitor = visitor;
     }
 
     protected final void output(String s) {

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/prism/PrismBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/prism/PrismBackend.java
@@ -34,6 +34,7 @@ import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.GlueBlock;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.TreeScanner;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
@@ -48,11 +49,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class PrismBackend extends TreeScanner {
 
     private JSLParser parser;
+    private JSLVisitor visitor;
     private StringBuilder usercode = new StringBuilder();
     private boolean isPixcoordReferenced = false;
 
-    public PrismBackend(JSLParser parser, ProgramUnit program) {
+    public PrismBackend(JSLParser parser, JSLVisitor visitor, ProgramUnit program) {
         this.parser = parser;
+        this.visitor = visitor;
         scan(program);
     }
 
@@ -66,7 +69,7 @@ public class PrismBackend extends TreeScanner {
                               String genericsName,
                               String interfaceName)
     {
-        Map<String, Variable> vars = parser.getSymbolTable().getGlobalVariables();
+        Map<String, Variable> vars = visitor.getSymbolTable().getGlobalVariables();
         StringBuilder genericsDecl = new StringBuilder();
         StringBuilder interfaceDecl = new StringBuilder();
         StringBuilder samplerLinear = new StringBuilder();
@@ -107,7 +110,7 @@ public class PrismBackend extends TreeScanner {
             }
         }
 
-        int numSamplers = parser.getSymbolTable().getNumSamplers();
+        int numSamplers = visitor.getSymbolTable().getNumSamplers();
         String superClass;
         if (numSamplers == 0) {
             superClass = "PPSZeroSamplerPeer";

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/java/JSWBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/java/JSWBackend.java
@@ -37,6 +37,7 @@ import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.TreeScanner;
 import org.stringtemplate.v4.ST;
@@ -50,13 +51,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class JSWBackend extends TreeScanner {
 
     private final JSLParser parser;
+    private final JSLVisitor visitor;
     private final String body;
 
-    public JSWBackend(JSLParser parser, ProgramUnit program) {
+    public JSWBackend(JSLParser parser, JSLVisitor visitor, ProgramUnit program) {
         // TODO: will be removed once we clean up static usage
         resetStatics();
 
         this.parser = parser;
+        this.visitor = visitor;
 
         JSWTreeScanner scanner = new JSWTreeScanner();
         scanner.scan(program);
@@ -68,7 +71,7 @@ public class JSWBackend extends TreeScanner {
                                    String genericsName,
                                    String interfaceName)
     {
-        Map<String, Variable> vars = parser.getSymbolTable().getGlobalVariables();
+        Map<String, Variable> vars = visitor.getSymbolTable().getGlobalVariables();
         StringBuilder genericsDecl = new StringBuilder();
         StringBuilder interfaceDecl = new StringBuilder();
         StringBuilder constants = new StringBuilder();

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/me/MEBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/me/MEBackend.java
@@ -37,6 +37,7 @@ import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.TreeScanner;
 import org.stringtemplate.v4.ST;
@@ -50,13 +51,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class MEBackend extends TreeScanner {
 
     private final JSLParser parser;
+    private final JSLVisitor visitor;
     private final String body;
 
-    public MEBackend(JSLParser parser, ProgramUnit program) {
+    public MEBackend(JSLParser parser, JSLVisitor visitor, ProgramUnit program) {
         // TODO: will be removed once we clean up static usage
         resetStatics();
 
         this.parser = parser;
+        this.visitor = visitor;
 
         METreeScanner scanner = new METreeScanner();
         scanner.scan(program);
@@ -84,7 +87,7 @@ public class MEBackend extends TreeScanner {
                                     String genericsName,
                                     String interfaceName)
     {
-        Map<String, Variable> vars = parser.getSymbolTable().getGlobalVariables();
+        Map<String, Variable> vars = visitor.getSymbolTable().getGlobalVariables();
         StringBuilder genericsDecl = new StringBuilder();
         StringBuilder interfaceDecl = new StringBuilder();
         StringBuilder constants = new StringBuilder();

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/sse/SSEBackend.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/backend/sw/sse/SSEBackend.java
@@ -41,6 +41,7 @@ import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.TreeScanner;
 import org.stringtemplate.v4.ST;
@@ -54,13 +55,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class SSEBackend extends TreeScanner {
 
     private final JSLParser parser;
+    private final JSLVisitor visitor;
     private final String body;
 
-    public SSEBackend(JSLParser parser, ProgramUnit program) {
+    public SSEBackend(JSLParser parser, JSLVisitor visitor, ProgramUnit program) {
         // TODO: will be removed once we clean up static usage
         resetStatics();
 
         this.parser = parser;
+        this.visitor = visitor;
 
         SSETreeScanner scanner = new SSETreeScanner();
         scanner.scan(program);
@@ -95,7 +98,7 @@ public class SSEBackend extends TreeScanner {
                                     String genericsName,
                                     String interfaceName)
     {
-        Map<String, Variable> vars = parser.getSymbolTable().getGlobalVariables();
+        Map<String, Variable> vars = visitor.getSymbolTable().getGlobalVariables();
         StringBuilder genericsDecl = new StringBuilder();
         StringBuilder interfaceDecl = new StringBuilder();
         StringBuilder constants = new StringBuilder();

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/CallExpr.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/CallExpr.java
@@ -36,7 +36,7 @@ public class CallExpr extends Expr {
     private final List<Expr> params;
 
     CallExpr(Function func, List<Expr> params) {
-        super(func.getReturnType());
+        super(func != null ? func.getReturnType() : null);
         this.func = func;
         this.params = params;
     }

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/JSLVisitor.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/JSLVisitor.java
@@ -1,0 +1,756 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.scenario.effect.compiler.tree;
+
+import com.sun.scenario.effect.compiler.JSLBaseVisitor;
+import com.sun.scenario.effect.compiler.JSLParser;
+import com.sun.scenario.effect.compiler.model.BinaryOpType;
+import com.sun.scenario.effect.compiler.model.Function;
+import com.sun.scenario.effect.compiler.model.Param;
+import com.sun.scenario.effect.compiler.model.Precision;
+import com.sun.scenario.effect.compiler.model.Qualifier;
+import com.sun.scenario.effect.compiler.model.SymbolTable;
+import com.sun.scenario.effect.compiler.model.Type;
+import com.sun.scenario.effect.compiler.model.UnaryOpType;
+import com.sun.scenario.effect.compiler.model.Variable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JSLVisitor extends JSLBaseVisitor<Tree> {
+    private SymbolTable symbols = new SymbolTable();
+    private TreeMaker tm = new TreeMaker(symbols);
+
+    public SymbolTable getSymbolTable() {
+        return symbols;
+    }
+
+    public static class StringExpr extends Expr {
+        private final String string;
+
+        StringExpr(String string) {
+            super(Type.SAMPLER); // dummy
+            this.string = string;
+        }
+
+        public String getString() {
+            return string;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    public static class FullySpecifiedTypeExpr extends Expr {
+        private final Qualifier qual;
+        private final Precision precision;
+        private final Type type;
+
+        public FullySpecifiedTypeExpr(Qualifier qual, Precision precision, Type type) {
+            super(Type.SAMPLER); // dummy
+            this.qual = qual;
+            this.precision = precision;
+            this.type = type;
+        }
+
+        public Qualifier getQual() {
+            return qual;
+        }
+
+        public Precision getPrecision() {
+            return precision;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    public static class ForRestExpr extends Expr {
+        private final Expr cond;
+        private final Expr expr;
+
+        ForRestExpr(Expr cond, Expr expr) {
+            super(Type.SAMPLER); // dummy
+            this.cond = cond;
+            this.expr = expr;
+        }
+
+        public Expr getCond() {
+            return cond;
+        }
+
+        public Expr getExpr() {
+            return expr;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    public static class ParamExpr extends Expr {
+        private final Param param;
+
+        public ParamExpr(Param param) {
+            super(Type.SAMPLER); // dummy
+            this.param = param;
+        }
+
+        public Param getParam() {
+            return param;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    public static class ParamListExpr extends Expr {
+        private final List<Param> paramList;
+
+        public ParamListExpr(List<Param> paramList) {
+            super(Type.SAMPLER); // dummy
+            this.paramList = paramList;
+        }
+
+        public List<Param> getParamList() {
+            return paramList;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    public static class DeclIdInitExpr extends Expr {
+        private final String name;
+        private final Expr arrayInit;
+        private final Expr init;
+
+        public DeclIdInitExpr(String name, Expr arrayInit, Expr init) {
+            super(Type.SAMPLER); // dummy
+            this.name = name;
+            this.arrayInit = arrayInit;
+            this.init = init;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Expr getArrayInit() {
+            return arrayInit;
+        }
+
+        public Expr getInit() {
+            return init;
+        }
+
+        @Override
+        public void accept(TreeVisitor tv) {}
+    }
+
+    @Override
+    public StringExpr visitField_selection(JSLParser.Field_selectionContext ctx) {
+        if (ctx.RGBA_FIELDS() != null) {
+            return new StringExpr(ctx.r.getText());
+        } else if (ctx.XYZW_FIELDS() != null) {
+            return new StringExpr(ctx.x.getText());
+        }
+        throw new RuntimeException("invalid field selection");
+    }
+
+    @Override
+    public Expr visitPrimary_expression(JSLParser.Primary_expressionContext ctx) {
+        if (ctx.IDENTIFIER() != null) {
+            return tm.variable(ctx.IDENTIFIER().getText());
+        } else if (ctx.INTCONSTANT() != null) {
+            return tm.literal(Type.INT, Integer.valueOf(ctx.INTCONSTANT().getText()));
+        } else if (ctx.FLOATCONSTANT() != null) {
+            return tm.literal(Type.FLOAT, Float.valueOf(ctx.FLOATCONSTANT().getText()));
+        } else if (ctx.BOOLCONSTANT() != null) {
+            return tm.literal(Type.BOOL, Boolean.valueOf(ctx.BOOLCONSTANT().getText()));
+        } else if (ctx.e != null) {
+            return tm.parenExpr(visitExpression(ctx.e));
+        }
+
+        throw new RuntimeException("invalid primary expression");
+    }
+
+    @Override
+    public Expr visitPrimary_or_call(JSLParser.Primary_or_callContext ctx) {
+        if (ctx.primary_expression() != null) {
+            return visitPrimary_expression(ctx.e);
+        } else if (ctx.function_call() != null) {
+            return visitFunction_call(ctx.f);
+        }
+
+        throw new RuntimeException("invalid primary or call");
+    }
+
+    @Override
+    public Expr visitPostfix_expression(JSLParser.Postfix_expressionContext ctx) {
+        if (ctx.expression() != null) {
+            if (ctx.field_selection() != null) {
+                return tm.fieldSelect(tm.arrayAccess(visitPrimary_or_call(ctx.e), visitExpression(ctx.ae)),
+                        visitField_selection(ctx.fs).getString());
+            } else {
+                return tm.arrayAccess(visitPrimary_or_call(ctx.e), visitExpression(ctx.ae));
+            }
+        } else if (ctx.field_selection() != null) {
+            return tm.fieldSelect(visitPrimary_or_call(ctx.e), visitField_selection(ctx.fs).getString());
+        } else if (ctx.INC() != null) {
+            return tm.unary(UnaryOpType.INC, visitPrimary_or_call(ctx.e));
+        } else if (ctx.DEC() != null) {
+            return tm.unary(UnaryOpType.DEC, visitPrimary_or_call(ctx.e));
+        } else if (ctx.e != null){
+            return visitPrimary_or_call(ctx.e);
+        }
+
+        throw new RuntimeException("invalid postfix expression");
+    }
+
+    @Override
+    public Expr visitFunction_call(JSLParser.Function_callContext ctx) {
+        if (ctx.IDENTIFIER() != null) {
+            return tm.call(ctx.IDENTIFIER().getText(), ctx.function_call_parameter_list() != null ?
+                    visitFunction_call_parameter_list(ctx.p).getParams() : null);
+        } else if (ctx.type_specifier() != null) {
+            Type type = Type.fromToken(ctx.ts.getText());
+            return tm.vectorCtor(type, ctx.function_call_parameter_list() != null ?
+                    visitFunction_call_parameter_list(ctx.p).getParams() : null);
+        }
+
+        throw new RuntimeException("invalid function call");
+    }
+
+    @Override
+    public CallExpr visitFunction_call_parameter_list(JSLParser.Function_call_parameter_listContext ctx) {
+        List<Expr> list = new ArrayList<>();
+        for (JSLParser.Assignment_expressionContext aeCtx : ctx.assignment_expression()) {
+            list.add(visitAssignment_expression(aeCtx));
+        }
+        return new CallExpr(null, list);
+    }
+
+    @Override
+    public Expr visitUnary_expression(JSLParser.Unary_expressionContext ctx) {
+        if (ctx.INC() != null) {
+            return tm.unary(UnaryOpType.INC, visitUnary_expression(ctx.u));
+        } else if (ctx.DEC() != null) {
+            return tm.unary(UnaryOpType.DEC, visitUnary_expression(ctx.u));
+        } else if (ctx.PLUS() != null) {
+            return tm.unary(UnaryOpType.PLUS, visitUnary_expression(ctx.u));
+        } else if (ctx.DASH() != null) {
+            return tm.unary(UnaryOpType.MINUS, visitUnary_expression(ctx.u));
+        } else if (ctx.BANG() != null) {
+            return tm.unary(UnaryOpType.NOT, visitUnary_expression(ctx.u));
+        } else if (ctx.postfix_expression() != null){
+            return visitPostfix_expression(ctx.p);
+        }
+
+        throw new RuntimeException("invalid unary expression");
+    }
+
+    @Override
+    public Expr visitMultiplicative_expression(JSLParser.Multiplicative_expressionContext ctx) {
+        Expr expr = visitUnary_expression(ctx.a);
+
+        if (ctx.multiplicative_operator() != null) {
+            for (int i = 0; i < ctx.multiplicative_expression().size(); i++) {
+                JSLParser.Multiplicative_expressionContext context = ctx.multiplicative_expression(i);
+                switch (ctx.multiplicative_operator(i).getText()) {
+                    case "*":
+                        expr = tm.binary(BinaryOpType.MUL, expr, visitMultiplicative_expression(context));
+                        break;
+                    case "/":
+                        expr = tm.binary(BinaryOpType.DIV, expr, visitMultiplicative_expression(context));
+                        break;
+                    default:
+                        throw new RuntimeException("unexpected multiplicative operator");
+                }
+            }
+        }
+        return expr;
+    }
+
+    @Override
+    public Expr visitAdditive_expression(JSLParser.Additive_expressionContext ctx) {
+        Expr expr = visitMultiplicative_expression(ctx.a);
+
+        if (ctx.additive_operator() != null) {
+            for (int i = 1; i < ctx.multiplicative_expression().size(); i++) {
+                JSLParser.Multiplicative_expressionContext context = ctx.multiplicative_expression(i);
+                switch (ctx.additive_operator(i - 1).getText()) {
+                    case "+":
+                        expr = tm.binary(BinaryOpType.ADD, expr, visitMultiplicative_expression(context));
+                        break;
+                    case "-":
+                        expr = tm.binary(BinaryOpType.SUB, expr, visitMultiplicative_expression(context));
+                        break;
+                    default:
+                        throw new RuntimeException("unexpected additive operator");
+                }
+            }
+        }
+        return expr;
+    }
+
+    @Override
+    public Expr visitRelational_expression(JSLParser.Relational_expressionContext ctx) {
+        Expr expr = visitAdditive_expression(ctx.a);
+
+        if (ctx.relational_operator() != null) {
+            for (int i = 1; i < ctx.additive_expression().size(); i++) {
+                JSLParser.Additive_expressionContext context = ctx.additive_expression(i);
+                switch (ctx.relational_operator(i - 1).getText()) {
+                    case "<=":
+                        expr = tm.binary(BinaryOpType.LTEQ, expr, visitAdditive_expression(context));
+                        break;
+                    case ">=":
+                        expr = tm.binary(BinaryOpType.GTEQ, expr, visitAdditive_expression(context));
+                        break;
+                    case "<":
+                        expr = tm.binary(BinaryOpType.LT, expr, visitAdditive_expression(context));
+                        break;
+                    case ">":
+                        expr = tm.binary(BinaryOpType.GT, expr, visitAdditive_expression(context));
+                        break;
+                    default:
+                        throw new RuntimeException("unexpected relational operator");
+                }
+            }
+
+            return expr;
+        }
+
+        return expr;
+    }
+
+    @Override
+    public Expr visitEquality_expression(JSLParser.Equality_expressionContext ctx){
+        Expr expr = visitRelational_expression(ctx.a);
+
+        for (int i = 1; i < ctx.relational_expression().size(); i++) {
+            JSLParser.Relational_expressionContext context = ctx.relational_expression(i);
+            switch (ctx.equality_operator(i - 1).getText()) {
+                case "==":
+                    expr = tm.binary(BinaryOpType.EQEQ, expr, visitRelational_expression(context));
+                    break;
+                case "!=":
+                    expr = tm.binary(BinaryOpType.NEQ, expr, visitRelational_expression(context));
+                    break;
+                default:
+                    throw new RuntimeException("unexpected equality operator");
+            }
+        }
+
+        return expr;
+    }
+
+    @Override
+    public Expr visitLogical_and_expression(JSLParser.Logical_and_expressionContext ctx) {
+        Expr expr = visitEquality_expression(ctx.a);
+        for (JSLParser.Equality_expressionContext eqContext :
+                ctx.equality_expression().subList(1, ctx.equality_expression().size())) {
+            expr = tm.binary(BinaryOpType.AND, expr, visitEquality_expression(eqContext));
+        }
+        return expr;
+    }
+
+    @Override
+    public Expr visitLogical_xor_expression(JSLParser.Logical_xor_expressionContext ctx) {
+        Expr expr = visitLogical_and_expression(ctx.a);
+
+        for (JSLParser.Logical_and_expressionContext andContext :
+                ctx.logical_and_expression().subList(1, ctx.logical_and_expression().size())) {
+            expr = tm.binary(BinaryOpType.XOR, expr, visitLogical_and_expression(andContext));
+        }
+        return expr;
+    }
+
+    @Override
+    public Expr visitLogical_or_expression(JSLParser.Logical_or_expressionContext ctx) {
+        Expr expr = visitLogical_xor_expression(ctx.a);
+        for (JSLParser.Logical_xor_expressionContext xorContext :
+                ctx.logical_xor_expression().subList(1, ctx.logical_xor_expression().size())) {
+            expr = tm.binary(BinaryOpType.OR, expr, visitLogical_xor_expression(xorContext));
+        }
+        return expr;
+    }
+
+    @Override
+    public Expr visitConditional_expression(JSLParser.Conditional_expressionContext ctx) {
+        return visitLogical_or_expression(ctx.a);
+    }
+
+    @Override
+    public Expr visitAssignment_expression(JSLParser.Assignment_expressionContext ctx) {
+        if (ctx.conditional_expression() != null) {
+            return visitConditional_expression(ctx.c);
+        } else {
+            return tm.binary(BinaryOpType.forSymbol(ctx.op.getText()),
+                    visitUnary_expression(ctx.a), visitAssignment_expression(ctx.b));
+        }
+    }
+
+    @Override
+    public Expr visitExpression(JSLParser.ExpressionContext ctx) {
+        return visitAssignment_expression(ctx.e);
+    }
+
+    @Override
+    public Stmt visitJump_statement(JSLParser.Jump_statementContext ctx) {
+        if (ctx.CONTINUE() != null) {
+            return tm.continueStmt();
+        } else if (ctx.BREAK() != null) {
+            return tm.breakStmt();
+        } else if (ctx.DISCARD() != null) {
+            return tm.discardStmt();
+        } else if (ctx.RETURN() != null) {
+            if (ctx.e != null) {
+                return tm.returnStmt(visitExpression(ctx.e));
+            } else {
+                return tm.returnStmt(null);
+            }
+        }
+
+        throw new RuntimeException("invalid jump statement");
+    }
+
+    @Override
+    public FullySpecifiedTypeExpr visitFully_specified_type(JSLParser.Fully_specified_typeContext ctx) {
+        return new FullySpecifiedTypeExpr(
+                ctx.type_qualifier() != null ? Qualifier.fromToken(ctx.tq.getText()) : null,
+                ctx.type_precision() != null ? Precision.fromToken(ctx.tp.getText()) : null,
+                ctx.type_specifier() != null ? Type.fromToken(ctx.ts.getText()) : null);
+    }
+
+    @Override
+    public Stmt visitSelection_statement(JSLParser.Selection_statementContext ctx) {
+        return tm.selectStmt(visitExpression(ctx.e), visitStatement(ctx.a),
+                ctx.b != null ? visitStatement(ctx.b) : null);
+    }
+
+    @Override
+    public Stmt visitExpression_statement(JSLParser.Expression_statementContext ctx) {
+        if (ctx.e != null) {
+            return tm.exprStmt(visitExpression(ctx.e));
+        } else if (ctx.SEMICOLON() != null) {
+            return tm.exprStmt(null);
+        }
+        throw new RuntimeException("invalid expression statement");
+    }
+
+    @Override
+    public Expr visitConstant_expression(JSLParser.Constant_expressionContext ctx) {
+        return visitConditional_expression(ctx.c);
+    }
+
+    @Override
+    public Stmt visitFor_init_statement(JSLParser.For_init_statementContext ctx) {
+        if (ctx.expression_statement() != null) {
+            return visitExpression_statement(ctx.e);
+        } else if (ctx.declaration_statement() != null) {
+            return visitDeclaration_statement(ctx.d);
+        }
+        throw new RuntimeException("invalid for init statement");
+    }
+
+    @Override
+    public Expr visitCondition(JSLParser.ConditionContext ctx) {
+        if (ctx.expression() != null) {
+            return visitExpression(ctx.e);
+        }
+        throw new RuntimeException("invalid condition");
+    }
+
+    @Override
+    public Stmt visitSimple_statement(JSLParser.Simple_statementContext ctx) {
+        if (ctx.declaration_statement() != null) {
+            return visitDeclaration_statement(ctx.d);
+        } else if (ctx.expression_statement() != null) {
+            return visitExpression_statement(ctx.e);
+        } else if (ctx.selection_statement() != null) {
+            return visitSelection_statement(ctx.s);
+        } else if (ctx.iteration_statement() != null) {
+            return visitIteration_statement(ctx.i);
+        } else if (ctx.jump_statement() != null) {
+            return visitJump_statement(ctx.j);
+        }
+
+        throw new RuntimeException("invalid simple statement");
+    }
+
+    @Override
+    public Stmt visitStatement(JSLParser.StatementContext ctx) {
+        if (ctx.compound_statement() != null) {
+            return visitCompound_statement(ctx.c);
+        } else if (ctx.simple_statement() != null) {
+            return visitSimple_statement(ctx.s);
+        }
+
+        throw new RuntimeException("invalid statement");
+    }
+
+    @Override
+    public Stmt visitDeclaration_statement(JSLParser.Declaration_statementContext ctx) {
+        if (ctx.declaration() != null) {
+            return tm.declStmt(visitDeclaration(ctx.d).getDecls());
+        }
+
+        throw new RuntimeException("invalid declaration statement");
+    }
+
+    @Override
+    public Expr visitInitializer(JSLParser.InitializerContext ctx) {
+        if (ctx.assignment_expression() != null) {
+            return visitAssignment_expression(ctx.e);
+        }
+
+        throw new RuntimeException("invalid initializer");
+    }
+
+    @Override
+    public VarDecl visitSingle_declaration(JSLParser.Single_declarationContext ctx) {
+        if (ctx.fully_specified_type() != null && ctx.declaration_identifier_and_init() != null) {
+            int arraySize = -1;
+            DeclIdInitExpr initExpr = visitDeclaration_identifier_and_init(ctx.d);
+            FullySpecifiedTypeExpr typeExpr = visitFully_specified_type(ctx.t);
+            Expr ainit = initExpr.arrayInit;
+            if (ainit != null) {
+                if (ainit instanceof LiteralExpr) {
+                    Object val = ((LiteralExpr)ainit).getValue();
+                    if (!(val instanceof Integer)) {
+                        throw new RuntimeException("Array size must be an integer");
+                    }
+                    arraySize = (Integer) val;
+                } else if (ainit instanceof VariableExpr) {
+                    Variable var = ((VariableExpr)ainit).getVariable();
+                    Object val = var.getConstValue();
+                    if (!(val instanceof Integer) || var.getQualifier() != Qualifier.CONST) {
+                        throw new RuntimeException("Array size must be a constant integer");
+                    }
+                    arraySize = (Integer) val;
+                }
+            }
+
+            Object constValue = null;
+            if (typeExpr.qual == Qualifier.CONST) {
+                Expr cinit = initExpr.init;
+                if (cinit == null) {
+                    throw new RuntimeException("Constant value must be initialized");
+                }
+                // TODO: for now, allow some basic expressions on the rhs
+                // of the constant declaration...
+                //if (!(cinit instanceof LiteralExpr)) {
+                //    throw new RuntimeException("Constant initializer must be a literal (for now)");
+                //}
+                Type ctype = cinit.getResultType();
+                if (ctype != typeExpr.type) {
+                    throw new RuntimeException("Constant type must match that of initializer");
+                }
+                if (cinit instanceof LiteralExpr) {
+                    constValue = ((LiteralExpr)cinit).getValue();
+                } else {
+                    // TODO: This is gross, but to support complex constant
+                    // initializers (such as "const FOO = BAR / 42.0;") we
+                    // will just save the full text of the rhs and hope that
+                    // the backend does the right thing with it.  The real
+                    // solution obviously would be to evaluate the expression
+                    // now and reduce it to a single value.
+                    constValue = initExpr.init.toString();
+                }
+            }
+
+            Variable var = symbols.declareVariable(initExpr.name, typeExpr.type, typeExpr.qual,
+                    typeExpr.precision, arraySize, constValue);
+            return tm.varDecl(var, initExpr.init);
+        }
+
+        throw new RuntimeException("invalid single declaration");
+    }
+
+    @Override
+    public Stmt visitIteration_statement(JSLParser.Iteration_statementContext ctx) {
+        if (ctx.WHILE() != null) {
+            if (ctx.DO() != null) {
+                return tm.doWhileStmt(visitStatement(ctx.s), visitExpression(ctx.e));
+            } else if (ctx.condition() != null) {
+                return tm.whileStmt(visitCondition(ctx.c), visitStatement_no_new_scope(ctx.snns));
+            }
+            return tm.whileStmt(visitCondition(ctx.c), visitStatement_no_new_scope(ctx.snns));
+        } else if (ctx.FOR() != null) {
+            ForRestExpr forRestExpr = visitFor_rest_statement(ctx.rem);
+            if (ctx.unroll_modifier() != null) {
+                ForStmt unrollStmt = visitUnroll_modifier(ctx.u);
+                return tm.forStmt(visitFor_init_statement(ctx.init),
+                        forRestExpr.cond, forRestExpr.expr,
+                        visitStatement_no_new_scope(ctx.snns), unrollStmt.getUnrollMax(), unrollStmt.getUnrollCheck());
+            } else {
+                return tm.forStmt(visitFor_init_statement(ctx.init),
+                        forRestExpr.cond, forRestExpr.expr,
+                        visitStatement_no_new_scope(ctx.snns), -1, -1);
+
+            }
+        }
+
+        throw new RuntimeException("invalid iteration statement");
+    }
+
+    @Override
+    public Stmt visitCompound_statement(JSLParser.Compound_statementContext ctx) {
+        List<Stmt> stmtList = new ArrayList<>();
+        for (JSLParser.StatementContext sCtx : ctx.statement()) {
+            stmtList.add(visitStatement(sCtx));
+        }
+        return tm.compoundStmt(stmtList);
+    }
+
+    @Override
+    public Stmt visitStatement_no_new_scope(JSLParser.Statement_no_new_scopeContext ctx) {
+        if (ctx.compound_statement_no_new_scope() != null) {
+            return visitCompound_statement_no_new_scope(ctx.c);
+        } else if (ctx.simple_statement() != null) {
+            return visitSimple_statement(ctx.s);
+        }
+        throw new RuntimeException("invalid statement no new scope");
+    }
+
+    @Override
+    public Stmt visitCompound_statement_no_new_scope(JSLParser.Compound_statement_no_new_scopeContext ctx) {
+        List<Stmt> stmtList = new ArrayList<>();
+        for (JSLParser.StatementContext sCtx : ctx.statement()) {
+            stmtList.add(visitStatement(sCtx));
+        }
+        return tm.compoundStmt(stmtList);
+    }
+
+    @Override
+    public ForStmt visitUnroll_modifier(JSLParser.Unroll_modifierContext ctx) {
+        return new ForStmt(null, null, null, null, Integer.valueOf(ctx.m.getText()), Integer.valueOf(ctx.c.getText()));
+    }
+
+    @Override
+    public ForRestExpr visitFor_rest_statement(JSLParser.For_rest_statementContext ctx) {
+        if (ctx.condition() != null) {
+            return new ForRestExpr(visitCondition(ctx.c), ctx.expression() != null ? visitExpression(ctx.e) : null);
+        } else {
+            return new ForRestExpr(null, ctx.expression() != null ? visitExpression(ctx.e) : null);
+        }
+    }
+
+    @Override
+    public ProgramUnit visitTranslation_unit(JSLParser.Translation_unitContext ctx) {
+        List<ExtDecl> declList = new ArrayList<>();
+        for (JSLParser.External_declarationContext eDeclCtx : ctx.external_declaration()) {
+            declList.addAll(visitExternal_declaration(eDeclCtx).getDecls());
+        }
+        return tm.programUnit(declList);
+    }
+
+    @Override
+    public ProgramUnit visitExternal_declaration(JSLParser.External_declarationContext ctx) {
+        List<ExtDecl> res = new ArrayList<>();
+        if (ctx.function_definition() != null) {
+            res.add(visitFunction_definition(ctx.f));
+        } else if (ctx.declaration() != null) {
+            res.addAll(visitDeclaration(ctx.d).getDecls());
+        } else if (ctx.glue_block() != null) {
+            res.add(visitGlue_block(ctx.g));
+        }
+        return new ProgramUnit(res);
+    }
+
+    @Override
+    public FuncDef visitFunction_definition(JSLParser.Function_definitionContext ctx) {
+        symbols.enterFrame();
+        FuncDef funcDef = tm.funcDef(visitFunction_prototype(ctx.p).getFunction(),
+                visitCompound_statement_no_new_scope(ctx.s));
+        symbols.exitFrame();
+        return funcDef;
+    }
+
+    @Override
+    public CallExpr visitFunction_prototype(JSLParser.Function_prototypeContext ctx) {
+        Type type = Type.fromToken(ctx.t.getText());
+        List<Param> params = ctx.parameter_declaration_list() != null ?
+                visitParameter_declaration_list(ctx.p).paramList : null;
+        Function func = symbols.declareFunction(ctx.id.getText(), type, params);
+        return new CallExpr(func, null);
+    }
+
+    @Override
+    public ParamExpr visitParameter_declaration(JSLParser.Parameter_declarationContext ctx) {
+        Type type = Type.fromToken(ctx.t.getText());
+        return new ParamExpr(new Param(ctx.IDENTIFIER().getText(), type));
+    }
+
+    @Override
+    public ParamListExpr visitParameter_declaration_list(JSLParser.Parameter_declaration_listContext ctx) {
+        List<Param> paramList = new ArrayList<>();
+        for (JSLParser.Parameter_declarationContext pdCtx : ctx.parameter_declaration()) {
+            paramList.add(visitParameter_declaration(pdCtx).param);
+        }
+        return new ParamListExpr(paramList);
+    }
+
+    @Override
+    public DeclStmt visitDeclaration(JSLParser.DeclarationContext ctx) {
+        List<VarDecl> declList = new ArrayList<>();
+        VarDecl varDecl = visitSingle_declaration(ctx.s);
+        declList.add(varDecl);
+        for (JSLParser.Declaration_identifier_and_initContext dCtx : ctx.declaration_identifier_and_init()) {
+            DeclIdInitExpr initExpr = visitDeclaration_identifier_and_init(dCtx);
+            Variable base = varDecl.getVariable();
+            Variable var = symbols.declareVariable(initExpr.name, base.getType(),
+                    base.getQualifier(), base.getPrecision());
+            declList.add(tm.varDecl(var, initExpr.init));
+        }
+        return new DeclStmt(declList);
+    }
+
+    @Override
+    public DeclIdInitExpr visitDeclaration_identifier_and_init(JSLParser.Declaration_identifier_and_initContext ctx) {
+        String name = ctx.IDENTIFIER().getText();
+        Expr arrayInit = null;
+        Expr init = null;
+        if (ctx.constant_expression() != null) {
+            arrayInit = visitConstant_expression(ctx.ae);
+        }
+        if (ctx.initializer() != null) {
+            init = visitInitializer(ctx.e);
+        }
+        return new DeclIdInitExpr(name, arrayInit, init);
+    }
+
+    @Override
+    public GlueBlock visitGlue_block(JSLParser.Glue_blockContext ctx) {
+        return tm.glueBlock(ctx.g.getText().substring(2, ctx.g.getText().length() - 2));
+    }
+
+}

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/JSLVisitor.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/tree/JSLVisitor.java
@@ -283,15 +283,12 @@ public class JSLVisitor extends JSLBaseVisitor<Tree> {
         if (ctx.multiplicative_operator() != null) {
             for (int i = 0; i < ctx.multiplicative_expression().size(); i++) {
                 JSLParser.Multiplicative_expressionContext context = ctx.multiplicative_expression(i);
-                switch (ctx.multiplicative_operator(i).getText()) {
-                    case "*":
-                        expr = tm.binary(BinaryOpType.MUL, expr, visitMultiplicative_expression(context));
-                        break;
-                    case "/":
-                        expr = tm.binary(BinaryOpType.DIV, expr, visitMultiplicative_expression(context));
-                        break;
-                    default:
-                        throw new RuntimeException("unexpected multiplicative operator");
+                if (ctx.multiplicative_operator(i).STAR() != null) {
+                    expr = tm.binary(BinaryOpType.MUL, expr, visitMultiplicative_expression(context));
+                } else if (ctx.multiplicative_operator(i).SLASH() != null) {
+                    expr = tm.binary(BinaryOpType.DIV, expr, visitMultiplicative_expression(context));
+                } else {
+                    throw new RuntimeException("unexpected multiplicative operator");
                 }
             }
         }
@@ -305,15 +302,12 @@ public class JSLVisitor extends JSLBaseVisitor<Tree> {
         if (ctx.additive_operator() != null) {
             for (int i = 1; i < ctx.multiplicative_expression().size(); i++) {
                 JSLParser.Multiplicative_expressionContext context = ctx.multiplicative_expression(i);
-                switch (ctx.additive_operator(i - 1).getText()) {
-                    case "+":
-                        expr = tm.binary(BinaryOpType.ADD, expr, visitMultiplicative_expression(context));
-                        break;
-                    case "-":
-                        expr = tm.binary(BinaryOpType.SUB, expr, visitMultiplicative_expression(context));
-                        break;
-                    default:
-                        throw new RuntimeException("unexpected additive operator");
+                if (ctx.additive_operator(i - 1).PLUS() != null) {
+                    expr = tm.binary(BinaryOpType.ADD, expr, visitMultiplicative_expression(context));
+                } else if (ctx.additive_operator(i - 1).DASH() != null) {
+                    expr = tm.binary(BinaryOpType.SUB, expr, visitMultiplicative_expression(context));
+                } else {
+                    throw new RuntimeException("unexpected additive operator");
                 }
             }
         }
@@ -327,21 +321,16 @@ public class JSLVisitor extends JSLBaseVisitor<Tree> {
         if (ctx.relational_operator() != null) {
             for (int i = 1; i < ctx.additive_expression().size(); i++) {
                 JSLParser.Additive_expressionContext context = ctx.additive_expression(i);
-                switch (ctx.relational_operator(i - 1).getText()) {
-                    case "<=":
-                        expr = tm.binary(BinaryOpType.LTEQ, expr, visitAdditive_expression(context));
-                        break;
-                    case ">=":
-                        expr = tm.binary(BinaryOpType.GTEQ, expr, visitAdditive_expression(context));
-                        break;
-                    case "<":
-                        expr = tm.binary(BinaryOpType.LT, expr, visitAdditive_expression(context));
-                        break;
-                    case ">":
-                        expr = tm.binary(BinaryOpType.GT, expr, visitAdditive_expression(context));
-                        break;
-                    default:
-                        throw new RuntimeException("unexpected relational operator");
+                if (ctx.relational_operator(i - 1).LTEQ() != null) {
+                    expr = tm.binary(BinaryOpType.LTEQ, expr, visitAdditive_expression(context));
+                } else if (ctx.relational_operator(i - 1).GTEQ() != null) {
+                    expr = tm.binary(BinaryOpType.GTEQ, expr, visitAdditive_expression(context));
+                } else if (ctx.relational_operator(i - 1).LT() != null) {
+                    expr = tm.binary(BinaryOpType.LT, expr, visitAdditive_expression(context));
+                } else if (ctx.relational_operator(i - 1).GT() != null) {
+                    expr = tm.binary(BinaryOpType.GT, expr, visitAdditive_expression(context));
+                } else {
+                    throw new RuntimeException("unexpected relational operator");
                 }
             }
 
@@ -357,15 +346,12 @@ public class JSLVisitor extends JSLBaseVisitor<Tree> {
 
         for (int i = 1; i < ctx.relational_expression().size(); i++) {
             JSLParser.Relational_expressionContext context = ctx.relational_expression(i);
-            switch (ctx.equality_operator(i - 1).getText()) {
-                case "==":
-                    expr = tm.binary(BinaryOpType.EQEQ, expr, visitRelational_expression(context));
-                    break;
-                case "!=":
-                    expr = tm.binary(BinaryOpType.NEQ, expr, visitRelational_expression(context));
-                    break;
-                default:
-                    throw new RuntimeException("unexpected equality operator");
+            if (ctx.equality_operator(i - 1).EQEQ() != null) {
+                expr = tm.binary(BinaryOpType.EQEQ, expr, visitRelational_expression(context));
+            } else if (ctx.equality_operator(i - 1).NEQ() != null) {
+                expr = tm.binary(BinaryOpType.NEQ, expr, visitRelational_expression(context));
+            } else {
+                throw new RuntimeException("unexpected equality operator");
             }
         }
 

--- a/modules/javafx.graphics/src/main/jsl-prism/CompileJSL.java
+++ b/modules/javafx.graphics/src/main/jsl-prism/CompileJSL.java
@@ -29,6 +29,7 @@ import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.BaseType;
 import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Variable;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.ProgramUnit;
 import com.sun.scenario.effect.compiler.tree.TreeScanner;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
@@ -423,7 +424,7 @@ public class CompileJSL {
         File outFile = jslcinfo.getOutputFile("prism-ps/build/gensrc/{pkg}/shader/{name}_Loader.java");
         if (JSLC.outOfDate(outFile, sourcetime)) {
             if (pinfo == null) pinfo = JSLC.getParserInfo(source);
-            PrismLoaderBackend loaderBackend = new PrismLoaderBackend(pinfo.parser, pinfo.program);
+            PrismLoaderBackend loaderBackend = new PrismLoaderBackend(pinfo.visitor, pinfo.program);
             JSLC.write(loaderBackend.getGlueCode(name), outFile);
         }
     }
@@ -507,12 +508,12 @@ public class CompileJSL {
 }
 
 class PrismLoaderBackend extends TreeScanner {
-    private JSLParser parser;
+    private JSLVisitor visitor;
     private int maxTexCoordIndex = -1;
     private boolean isPixcoordReferenced = false;
 
-    public PrismLoaderBackend(JSLParser parser, ProgramUnit program) {
-        this.parser = parser;
+    public PrismLoaderBackend(JSLVisitor visitor, ProgramUnit program) {
+        this.visitor = visitor;
         scan(program);
     }
 
@@ -522,7 +523,7 @@ class PrismLoaderBackend extends TreeScanner {
     }
 
     public String getGlueCode(String shaderName) {
-        Map<String, Variable> vars = parser.getSymbolTable().getGlobalVariables();
+        Map<String, Variable> vars = visitor.getSymbolTable().getGlobalVariables();
         StringBuilder samplerInit = new StringBuilder();
         StringBuilder paramInit = new StringBuilder();
 

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/AddExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/AddExprTest.java
@@ -28,7 +28,7 @@ package com.sun.scenario.effect.compiler.parser;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.BinaryOpType;
 import com.sun.scenario.effect.compiler.tree.BinaryExpr;
-import com.sun.scenario.effect.compiler.tree.JSLCVisitor;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -69,7 +69,7 @@ public class AddExprTest extends MultExprTest {
 
     private BinaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        JSLCVisitor visitor = new JSLCVisitor();
+        JSLVisitor visitor = new JSLVisitor();
         return (BinaryExpr) visitor.visit(parser.additive_expression());
     }
 

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/AssignmentExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/AssignmentExprTest.java
@@ -30,6 +30,7 @@ import com.sun.scenario.effect.compiler.model.SymbolTable;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.BinaryExpr;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
 import com.sun.scenario.effect.compiler.tree.VectorCtorExpr;
@@ -115,13 +116,14 @@ public class AssignmentExprTest extends ParserBase {
 
     private BinaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        SymbolTable st = parser.getSymbolTable();
+        JSLVisitor visitor = new JSLVisitor();
+        SymbolTable st = visitor.getSymbolTable();
         st.declareVariable("foo", Type.FLOAT, null);
         st.declareVariable("readonly", Type.FLOAT, Qualifier.CONST);
         // trick test into thinking main() function is currently in
         // scope so that we can test core variables such as color and pos0
         st.enterFrame();
         st.declareFunction("main", Type.VOID, null);
-        return (BinaryExpr) parser.assignment_expression();
+        return (BinaryExpr) visitor.visit(parser.assignment_expression());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/EqualityExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/EqualityExprTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import com.sun.scenario.effect.compiler.model.BinaryOpType;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.BinaryExpr;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -74,7 +75,8 @@ public class EqualityExprTest extends ParserBase {
 
     private BinaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("foo", Type.INT, null);
-        return (BinaryExpr) parser.equality_expression();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("foo", Type.INT, null);
+        return (BinaryExpr) visitor.visit(parser.equality_expression());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/ExternalDeclarationTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/ExternalDeclarationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.Variable;
 import com.sun.scenario.effect.compiler.tree.ExtDecl;
 import com.sun.scenario.effect.compiler.tree.FuncDef;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.VarDecl;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Test;
@@ -132,6 +133,7 @@ public class ExternalDeclarationTest extends ParserBase {
 
     private List<ExtDecl> parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        return parser.external_declaration();
+        JSLVisitor visitor = new JSLVisitor();
+        return visitor.visitExternal_declaration(parser.external_declaration()).getDecls();
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/FieldSelectTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/FieldSelectTest.java
@@ -26,6 +26,7 @@
 package com.sun.scenario.effect.compiler.parser;
 
 import com.sun.scenario.effect.compiler.JSLParser;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import junit.framework.Assert;
 import junit.framework.AssertionFailedError;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -133,11 +134,12 @@ public class FieldSelectTest extends ParserBase {
 
     private String parseTreeFor(String text, boolean expectEx) throws Exception {
         JSLParser parser = parserOver(text);
-        String ret = parser.field_selection();
+        JSLVisitor visitor = new JSLVisitor();
+        String ret = visitor.visitField_selection(parser.field_selection()).getString();
         // TODO: there's probably a better way to check for trailing (invalid) characters
         boolean sawException = false;
         try {
-            parser.field_selection();
+            visitor.visitField_selection(parser.field_selection());
         } catch (Exception e) {
             sawException = true;
         }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/FullySpecifiedTypeTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/FullySpecifiedTypeTest.java
@@ -26,9 +26,10 @@
 package com.sun.scenario.effect.compiler.parser;
 
 import com.sun.scenario.effect.compiler.JSLParser;
-import com.sun.scenario.effect.compiler.JSLParser.fully_specified_type_return;
+import com.sun.scenario.effect.compiler.JSLParser.Fully_specified_typeContext;
 import com.sun.scenario.effect.compiler.model.Qualifier;
 import com.sun.scenario.effect.compiler.model.Type;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -38,16 +39,16 @@ public class FullySpecifiedTypeTest extends ParserBase {
 
     @Test
     public void unqualified() throws Exception {
-        fully_specified_type_return ret = parseTreeFor("float");
-        assertNull(ret.qual);
-        assertEquals(ret.type, Type.FLOAT);
+        JSLVisitor.FullySpecifiedTypeExpr ret = parseTreeFor("float");
+        assertNull(ret.getQual());
+        assertEquals(Type.FLOAT, ret.getType());
     }
 
     @Test
     public void qualified() throws Exception {
-        fully_specified_type_return ret = parseTreeFor("param bool3");
-        assertEquals(ret.qual, Qualifier.PARAM);
-        assertEquals(ret.type, Type.BOOL3);
+        JSLVisitor.FullySpecifiedTypeExpr ret = parseTreeFor("param bool3");
+        assertEquals(Qualifier.PARAM, ret.getQual());
+        assertEquals(Type.BOOL3, ret.getType());
     }
 
     @Test(expected = ParseCancellationException.class)
@@ -57,6 +58,7 @@ public class FullySpecifiedTypeTest extends ParserBase {
 
     private fully_specified_type_return parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        return parser.fully_specified_type();
+        JSLVisitor visitor = new JSLVisitor();
+        return (JSLVisitor.FullySpecifiedTypeExpr) visitor.visit(parser.fully_specified_type());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/IterationStatementTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/IterationStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import com.sun.scenario.effect.compiler.tree.BinaryExpr;
 import com.sun.scenario.effect.compiler.tree.DoWhileStmt;
 import com.sun.scenario.effect.compiler.tree.ExprStmt;
 import com.sun.scenario.effect.compiler.tree.ForStmt;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.Stmt;
 import com.sun.scenario.effect.compiler.tree.WhileStmt;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -109,8 +110,9 @@ public class IterationStatementTest extends ParserBase {
 
     private Stmt parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("i", Type.INT, null);
-        parser.getSymbolTable().declareVariable("j", Type.INT, null);
-        return parser.iteration_statement();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("i", Type.INT, null);
+        visitor.getSymbolTable().declareVariable("j", Type.INT, null);
+        return visitor.visitIteration_statement(parser.iteration_statement());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/JumpStatementTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/JumpStatementTest.java
@@ -29,6 +29,7 @@ import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.tree.BreakStmt;
 import com.sun.scenario.effect.compiler.tree.ContinueStmt;
 import com.sun.scenario.effect.compiler.tree.DiscardStmt;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.ReturnStmt;
 import com.sun.scenario.effect.compiler.tree.Stmt;
@@ -82,6 +83,7 @@ public class JumpStatementTest extends ParserBase {
 
     private Stmt parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        return parser.jump_statement();
+        JSLVisitor visitor = new JSLVisitor();
+        return visitor.visitJump_statement(parser.jump_statement());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/MultExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/MultExprTest.java
@@ -28,6 +28,7 @@ package com.sun.scenario.effect.compiler.parser;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.BinaryOpType;
 import com.sun.scenario.effect.compiler.tree.BinaryExpr;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import org.antlr.runtime.RecognitionException;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +70,8 @@ public class MultExprTest extends UnaryExprTest {
 
     private BinaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        return (BinaryExpr)parser.multiplicative_expression();
+        JSLVisitor visitor = new JSLVisitor();
+        return (BinaryExpr) visitor.visit(parser.multiplicative_expression());
     }
 
     protected String multiplicative() {

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/ParserBase.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/ParserBase.java
@@ -28,7 +28,6 @@ package com.sun.scenario.effect.compiler.parser;
 import com.sun.scenario.effect.compiler.JSLLexer;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.ThrowingErrorListener;
-import com.sun.scenario.effect.compiler.tree.JSLCVisitor;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
@@ -28,6 +28,7 @@ package com.sun.scenario.effect.compiler.parser;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.tree.Expr;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -93,8 +94,9 @@ public class PrimaryExprTest extends ParserBase {
 
     private Expr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("foo", Type.INT, null);
-        return parser.primary_expression();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("foo", Type.INT, null);
+        return visitor.visitPrimary_expression(parser.primary_expression());
     }
 
     protected String primary() {

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/RelationalExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/RelationalExprTest.java
@@ -29,6 +29,7 @@ import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.BinaryOpType;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.tree.BinaryExpr;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Test;
 
@@ -67,7 +68,8 @@ public class RelationalExprTest extends ParserBase {
 
     private BinaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("foo", Type.INT, null);
-        return (BinaryExpr)parser.relational_expression();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("foo", Type.INT, null);
+        return (BinaryExpr) visitor.visit(parser.relational_expression());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/SelectionStatementTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/SelectionStatementTest.java
@@ -66,7 +66,8 @@ public class SelectionStatementTest extends ParserBase {
 
     private Stmt parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("foo", Type.INT, null);
-        return parser.selection_statement();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("foo", Type.INT, null);
+        return visitor.visitSelection_statement(parser.selection_statement());
     }
 }

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
@@ -28,6 +28,7 @@ package com.sun.scenario.effect.compiler.parser;
 import com.sun.scenario.effect.compiler.JSLParser;
 import com.sun.scenario.effect.compiler.model.Type;
 import com.sun.scenario.effect.compiler.model.UnaryOpType;
+import com.sun.scenario.effect.compiler.tree.JSLVisitor;
 import com.sun.scenario.effect.compiler.tree.LiteralExpr;
 import com.sun.scenario.effect.compiler.tree.UnaryExpr;
 import com.sun.scenario.effect.compiler.tree.VariableExpr;
@@ -103,9 +104,10 @@ public class UnaryExprTest extends PrimaryExprTest {
 
     private UnaryExpr parseTreeFor(String text) throws Exception {
         JSLParser parser = parserOver(text);
-        parser.getSymbolTable().declareVariable("foo", Type.INT, null);
-        parser.getSymbolTable().declareVariable("vec", Type.INT3, null);
-        return (UnaryExpr)parser.unary_expression();
+        JSLVisitor visitor = new JSLVisitor();
+        visitor.getSymbolTable().declareVariable("foo", Type.INT, null);
+        visitor.getSymbolTable().declareVariable("vec", Type.INT3, null);
+        return (UnaryExpr) visitor.visit(parser.unary_expression());
     }
 
     protected String unary() {


### PR DESCRIPTION
We can do this in antlr4 by using the new visitor mechanism. Keeping
the grammar definition separate from the logic (embedded actions) "promotes the separation
of concerns between parsing and parser application". It also makes the
grammar easier to read and understand.

This PR takes a direct approach to extracting the embedded actions and does not change the end results of a generated shader. That is, a shader generated with JSLC before this PR and after will be identical. Here is an example of such a migration (for the `unary_expression` rule):

Before this PR `unary_expression` is defined as a mixture of grammar and embedded actions (the parts in curly braces):

```
unary_expression returns [Expr expr]
        : p=postfix_expression     { $expr = $p.expr; }
        | INC   u=unary_expression { $expr = tm.unary(UnaryOpType.INC,     $u.expr); }
        | DEC   u=unary_expression { $expr = tm.unary(UnaryOpType.DEC,     $u.expr); }
        | PLUS  u=unary_expression { $expr = tm.unary(UnaryOpType.PLUS,    $u.expr); }
        | DASH  u=unary_expression { $expr = tm.unary(UnaryOpType.MINUS,   $u.expr); }
        | BANG  u=unary_expression { $expr = tm.unary(UnaryOpType.NOT,     $u.expr); }
;
```

This is changed to:

The grammar by itself with no embedded actions:

```
unary_expression
        : p=postfix_expression
        | INC   u=unary_expression
        | DEC   u=unary_expression
        | PLUS  u=unary_expression
        | DASH  u=unary_expression
        | BANG  u=unary_expression
;
```

and the following method of the `JSLVisitor` class, auto-generated by antlr4 (this is done because of the newly added `-visitor` parameter to the antlr4 program invocation), is implemented in our (new to this PR) `JSLVisitor` class (it's more complicated to explain in words than with code, lol):

```java
@Override
public Expr visitUnary_expression(JSLParser.Unary_expressionContext ctx) {
	if (ctx.INC() != null) {
		return tm.unary(UnaryOpType.INC, visitUnary_expression(ctx.u));
	} else if (ctx.DEC() != null) {
		return tm.unary(UnaryOpType.DEC, visitUnary_expression(ctx.u));
	} else if (ctx.PLUS() != null) {
		return tm.unary(UnaryOpType.PLUS, visitUnary_expression(ctx.u));
	} else if (ctx.DASH() != null) {
		return tm.unary(UnaryOpType.MINUS, visitUnary_expression(ctx.u));
	} else if (ctx.BANG() != null) {
		return tm.unary(UnaryOpType.NOT, visitUnary_expression(ctx.u));
	} else if (ctx.postfix_expression() != null){
		return visitPostfix_expression(ctx.p);
	}

	throw new RuntimeException("invalid unary expression");
}
```

This is a followup to the antlr4 migration PR and is based on my work from
https://github.com/javafxports/openjdk-jfx/pull/360 and https://github.com/brcolow/jslc/tree/jslc-antlr4
 - I have ran the tests from that repository and they all pass.

JBS Bug Filed: https://bugs.openjdk.java.net/browse/JDK-8221269
