### PR TITLE
JDK-8215686: FX build fails using gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1563,9 +1563,11 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                 maven(MavenPublication) {
                     artifactId = "javafx-${project.name}"
 
-                    artifact project.tasks."moduleEmptyPublicationJar$t.capital"
-                    artifact project.tasks."modularPublicationJar$t.capital" {
-                        classifier "$t.name"
+                    afterEvaluate {
+                        artifact project.tasks."moduleEmptyPublicationJar$t.capital"
+                        artifact project.tasks."modularPublicationJar$t.capital" {
+                            classifier "$t.name"
+                        }
                     }
 
                     pom.withXml {
@@ -3868,7 +3870,8 @@ compileTargets { t ->
         enabled = COMPILE_SWT
         group = "Basic"
         description = "Creates the javafx-swt.jar for the $t.name target"
-        archiveName = "${project(":swt").buildDir}/libs/javafx-swt.jar";
+        destinationDir = file("${project(":swt").buildDir}/libs")
+        archiveName = "javafx-swt.jar"
         includeEmptyDirs = false
         from("${project(":swt").buildDir}/classes/java/main");
         include("**/javafx/embed/swt/**")
@@ -3888,7 +3891,7 @@ compileTargets { t ->
         dependsOn(javafxSwtTask)
 
         doLast() {
-            ant.jar (update: true, index: true, destfile: javafxSwtTask.archiveName)
+            ant.jar (update: true, index: true, destfile: "${javafxSwtTask.destinationDir}/${javafxSwtTask.archiveName}")
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1564,6 +1564,12 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                     artifactId = "javafx-${project.name}"
 
                     afterEvaluate {
+                        // FIXME: remove debug print statements
+                        def moduleEmptyPublicationJarTask = project.tasks."moduleEmptyPublicationJar$t.capital"
+                        def modulePublicationJarTask = project.tasks."moduleEmptyPublicationJar$t.capital"
+                        println "KCR: publication artifact: ${moduleEmptyPublicationJarTask}"
+                        println "KCR: publication artifact: ${modulePublicationJarTask}"
+
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
                         artifact project.tasks."modularPublicationJar$t.capital" {
                             classifier "$t.name"
@@ -4427,6 +4433,8 @@ compileTargets { t ->
                 )
             }
         }
+        // FIXME: remove debug print statement
+        println "KCR: Created modularEmptyPublicationJarTask for $project"
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"
         def modularPublicationJarTask = project.task("modularPublicationJar${t.capital}", type: Jar, dependsOn: modularEmptyPublicationJarTask) {
@@ -4435,6 +4443,8 @@ compileTargets { t ->
             from srcLibsDir
             from srcClassesDir
         }
+        // FIXME: remove debug print statement
+        println "KCR: Created modularPublicationJarTask for $project"
 
         buildModulesTask.dependsOn(modularPublicationJarTask)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1564,12 +1564,6 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                     artifactId = "javafx-${project.name}"
 
                     afterEvaluate {
-                        // FIXME: remove debug print statements
-                        def moduleEmptyPublicationJarTask = project.tasks."moduleEmptyPublicationJar$t.capital"
-                        def modulePublicationJarTask = project.tasks."moduleEmptyPublicationJar$t.capital"
-                        println "KCR: publication artifact: ${moduleEmptyPublicationJarTask}"
-                        println "KCR: publication artifact: ${modulePublicationJarTask}"
-
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
                         artifact project.tasks."modularPublicationJar$t.capital" {
                             classifier "$t.name"
@@ -4433,8 +4427,6 @@ compileTargets { t ->
                 )
             }
         }
-        // FIXME: remove debug print statement
-        println "KCR: Created modularEmptyPublicationJarTask for $project"
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"
         def modularPublicationJarTask = project.task("modularPublicationJar${t.capital}", type: Jar, dependsOn: modularEmptyPublicationJarTask) {
@@ -4443,8 +4435,6 @@ compileTargets { t ->
             from srcLibsDir
             from srcClassesDir
         }
-        // FIXME: remove debug print statement
-        println "KCR: Created modularPublicationJarTask for $project"
 
         buildModulesTask.dependsOn(modularPublicationJarTask)
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
@@ -102,7 +102,7 @@ class NativeCompileTask extends DefaultTask {
         updateFiles();
         def source = project.files(allFiles);
         boolean forceCompile = false;
-        final Set<File> files = new HashSet<File>();
+        Set<File> files = new HashSet<File>();
         source.each { File file ->
             final Map fileData = dependencies.get(file.toString());
             final boolean isModified = fileData == null ||

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,10 @@ project(":web").projectDir = file("modules/javafx.web")
 project(":media").projectDir = file("modules/javafx.media")
 project(":systemTests").projectDir = file("tests/system")
 
+// Stable publishing behavior is the default in gradle 5.x.
+// This setting enables it in gradle 4.8 to help with the transition.
+enableFeaturePreview('STABLE_PUBLISHING')
+
 def closedDir = file("../rt-closed")
 def buildClosed = closedDir.isDirectory()
 


### PR DESCRIPTION
This is a preliminary review for [JDK-8215686](https://bugs.openjdk.java.net/browse/JDK-8215686) to allow the JavaFX to work with gradle 5.x, in support of upgrading to gradle 5.3 -- [JDK-8218172](https://bugs.openjdk.java.net/browse/JDK-8218172). It includes a fix for [JDK-8210509](https://bugs.openjdk.java.net/browse/JDK-8210509), since a gradle 5 build will fail without that fix.

I've run a build and test on Linux and compared the artifacts from the following builds:

gradle 4.8 without patch
gradle 4.8 with patch
gradle 5.3 with patch

All three sets of generated artifacts are identical.

The next steps are to test it on the other two platforms (Windows and Mac) and to verify the maven publishing step, which I didn't do. The (minor) changes to the maven publishing task were needed because gradle 5 no longer defers the configuration of publishing definition. I added some verbose print statements, which I will remove before the final review, to verify that the tasks are being configureed correctly.

@tiainen can you test this by publishing a snapshot build using `gradle publish`? Once you give the OK, I'll remove the verbose print statements and send out a formal review.