### PR TITLE
JDK-8210508: Update JDK_DOCS property to point to JDK 12 docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ defineProperty("JAVA", cygpathExe("$JDK_HOME/bin/java"))
 defineProperty("JAVAC", cygpathExe("$JDK_HOME/bin/javac"))
 defineProperty("JAVADOC", cygpathExe("$JDK_HOME/bin/javadoc"))
 defineProperty("JMOD", cygpathExe("$JDK_HOME/bin/jmod"))
-defineProperty("JDK_DOCS", "https://docs.oracle.com/javase/10/docs/api/")
+defineProperty("JDK_DOCS", "https://docs.oracle.com/en/java/javase/12/docs/api/")
 defineProperty("JDK_JMODS", cygpath(System.getenv("JDK_JMODS")) ?: cygpath(System.getenv("JDK_HOME") + "/jmods"))
 
 defineProperty("javaRuntimeVersion", System.getProperty("java.runtime.version"))


### PR DESCRIPTION
This fixes [JDK-8210508](https://bugs.openjdk.java.net/browse/JDK-8210508).

Now that we have switched to using JDK 12 as the boot JDK we can (and need to) update the JDK_DOCS property to point to the JDK 12 docs so that any links from JavaFX API docs to JDK docs are generated correctly.
