### PR TITLE
JDK-8218172: Upgrade to gradle 5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1235,7 +1235,7 @@ if (gradle.gradleVersion != jfxGradleVersion) {
 
     logger.warn("*****************************************************************");
     logger.warn("Unsupported gradle version $gradle.gradleVersion in use.");
-    logger.warn("Only version 5.3 is supported. Use this version at your own risk");
+    logger.warn("Only version $jfxGradleVersion is supported. Use this version at your own risk");
     if ( err != "") logger.warn(err);
     logger.warn("*****************************************************************");
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1216,14 +1216,17 @@ if (Integer.parseInt(NUM_COMPILE_THREADS.toString()) < 1) {
     NUM_COMPILE_THREADS = 1
 }
 
-// Check for Gradle 5.3, error if < 4.8.
-if (gradle.gradleVersion != "5.3") {
+// Check gradle version
+if (gradle.gradleVersion != jfxGradleVersion) {
     def ver = gradle.gradleVersion.split("[\\.]");
+    def verMin = jfxGradleVersionMin.split("[\\.]");
     def gradleMajor = Integer.parseInt(ver[0]);
     def gradleMinor = Integer.parseInt(ver[1].split("[^0-9]")[0]);
+    def gradleMajorMin = Integer.parseInt(verMin[0]);
+    def gradleMinorMin = Integer.parseInt(verMin[1].split("[^0-9]")[0]);
     def err = "";
-    if (gradleMajor < 4 || (gradleMajor == 4 && gradleMinor < 8)) {
-        err = "Gradle version too old: ${gradle.gradleVersion}; must be at least 4.8"
+    if (gradleMajor < gradleMajorMin || (gradleMajor == gradleMajorMin && gradleMinor < gradleMinorMin)) {
+        err = "Gradle version too old: ${gradle.gradleVersion}; must be at least ${jfxGradleVersionMin}"
     }
 
     if (IS_GRADLE_VERSION_CHECK && err != "") {

--- a/build.gradle
+++ b/build.gradle
@@ -1216,8 +1216,8 @@ if (Integer.parseInt(NUM_COMPILE_THREADS.toString()) < 1) {
     NUM_COMPILE_THREADS = 1
 }
 
-// Check for Gradle 4.8, error if < 4.8.
-if (gradle.gradleVersion != "4.8") {
+// Check for Gradle 5.3, error if < 4.8.
+if (gradle.gradleVersion != "5.3") {
     def ver = gradle.gradleVersion.split("[\\.]");
     def gradleMajor = Integer.parseInt(ver[0]);
     def gradleMinor = Integer.parseInt(ver[1].split("[^0-9]")[0]);
@@ -1232,7 +1232,7 @@ if (gradle.gradleVersion != "4.8") {
 
     logger.warn("*****************************************************************");
     logger.warn("Unsupported gradle version $gradle.gradleVersion in use.");
-    logger.warn("Only version 4.8 is supported. Use this version at your own risk");
+    logger.warn("Only version 5.3 is supported. Use this version at your own risk");
     if ( err != "") logger.warn(err);
     logger.warn("*****************************************************************");
 }

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -74,3 +74,12 @@ javadoc.header=JavaFX&nbsp;13
 
 jfx.build.jdk.version.min=11
 jfx.build.jdk.buildnum.min=28
+
+# The jfx.gradle.version property defines the version of gradle that is
+# used in the build. It must match the version number in
+# gradle/wrapper/gradle-wrapper.properties and should also be recorded in
+# gradle/legal/gradle.md.
+# The jfx.gradle.version.min property defines the minimum version of gradle
+# that is supported. It must be <= jfx.gradle.version.
+jfx.gradle.version=5.3
+jfx.gradle.version.min=4.8

--- a/gradle/legal/gradle.md
+++ b/gradle/legal/gradle.md
@@ -1,4 +1,4 @@
-## Gradle v4.8
+## Gradle v5.3
 
 ### Apache 2.0 License
 <pre>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8218172

This updates the gradle wrapper script to gradle 5.3. Production builds should start using 5.3 after this is merged.