### PR TITLE
WIP: JDK-8221691: CSS font caching could be improved

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -1544,7 +1544,7 @@ final class CssStyleHelper {
         }
         return cachedFont;
     }
-    
+
     private CalculatedValue getFont(final Styleable styleable) {
         if (styleable instanceof Node == false) return null;
         Node node = (Node)styleable;


### PR DESCRIPTION
Pointer to JBS issue: https://bugs.openjdk.java.net/browse/JDK-8221691

As discussed on the mailing list thread here: https://mail.openjdk.java.net/pipermail/openjfx-dev/2019-March/023157.html, this is what I believe is a better version of the fix here: https://github.com/DeanWookey/openjdk-jfx/commit/e12f00fb6c2fc690c0a7fb089f7b0c81d6930fa9

The idea is the same except the caching happens in one place instead of multiple places.

The only functional differences are the calls to getFont at the new line indexes: 1392 and 1688. getCachedFont used to return either a cached value which could never be null, or null. Now getFont never returns null so there is a difference. I believe this is fine because some amount of the time the value would be cached and return a non-null value of new CalculatedValue(Font.getDefault(), null, false);

What I'm saying is that the calling code was already dealing with both outcomes just fine, so nailing it down to just one outcome should be fine too. It's also desirable for reasoning about the code in the future.

