### PR TITLE
JDK-8222036: antlr generated files written to wrong location on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2456,14 +2456,7 @@ project(":graphics") {
 
     addMavenPublication(project, [ 'base' ])
 
-    /*
-     * The following is a workaroud for JDK-8222036 (antlr generated
-     * files written to wrong location on Windows). This workaround should
-     * be removed as part of fixing JDK-8222036.
-     */
-    // addValidateSourceSets(project, sourceSets)
-    def srcSets = sourceSets - sourceSets.jslc
-    addValidateSourceSets(project, srcSets)
+    addValidateSourceSets(project, sourceSets)
 }
 
 project(":controls") {

--- a/build.gradle
+++ b/build.gradle
@@ -2098,6 +2098,12 @@ project(":graphics") {
         // so we will do this by hand
 
         File wd = file(project.projectDir.path + "/src/jslc/antlr")
+        File outDir = file("$buildDir/gensrc/antlr")
+        def inJSL = "com/sun/scenario/effect/compiler/JSL.g4"
+        if (IS_WINDOWS) {
+            // antlr needs backslashes on Windows
+            inJSL = inJSL.replace("/", "\\")
+        }
 
         executable = JAVA
         classpath = project.configurations.antlr
@@ -2106,13 +2112,13 @@ project(":graphics") {
 
         args = [
             "-o",
-            "$buildDir/gensrc/antlr",
+            outDir.toString(),
             "-package",
             "com.sun.scenario.effect.compiler",
-            "com/sun/scenario/effect/compiler/JSL.g4" ]
+            inJSL ]
 
         inputs.dir wd
-        outputs.dir file("$buildDir/gensrc/antlr")
+        outputs.dir outDir
     }
     sourceSets.jslc.java.srcDirs += "$buildDir/gensrc/antlr"
 


### PR DESCRIPTION
See [JDK-8222036](https://bugs.openjdk.java.net/browse/JDK-8222036).

This fix accounts for a limitation of antlr on the Windows platform in that it won't write its output files to the proper location underneath the output directory tree unless the file name passed into antlr has Windows-style backslashes.

The fix is to ensure that we use backslashes as the file separator when running antlr.