### PR TITLE
Upgrade toolchains

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -88,9 +88,9 @@ jfx.gradle.version=5.3
 jfx.gradle.version.min=4.8
 
 # Toolchains
-jfx.build.linux.gcc.version=gcc7.3.0-OEL6.4+1.1
-jfx.build.windows.msvc.version=VS2017-15.5.5+1.1
-jfx.build.macosx.xcode.version=Xcode9.4-MacOSX10.13+1.0
+jfx.build.linux.gcc.version=gcc8.2.0-OL6.4+1.0
+jfx.build.windows.msvc.version=VS2017-15.9.6+1.0
+jfx.build.macosx.xcode.version=Xcode10.1-MacOSX10.14+1.0
 
 # Build tools
 jfx.build.cmake.version=3.13.3


### PR DESCRIPTION
This PR is targeted for the following bugs,

[JDK-8221300](https://bugs.openjdk.java.net/browse/JDK-8221300): Upgrade to Xcode 10.1
[JDK-8221302](https://bugs.openjdk.java.net/browse/JDK-8221302): Upgrade to gcc 8.2 on Linux
[JDK-8221299](https://bugs.openjdk.java.net/browse/JDK-8221299): Upgrade to Visual Studio 2017 version 15.9.6