### PR TITLE
JDK-8221702: Use HTTPS to download all build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1838,7 +1838,7 @@ allprojects {
         repositories {
             mavenCentral()
             ivy {
-                url "http://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
+                url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
                 layout "pattern", {
                     artifact "[artifact].[ext]"
                 }


### PR DESCRIPTION
This fixes [JDK-8221702](https://bugs.openjdk.java.net/browse/JDK-8221702).

We should always use HTTPS to download artifacts used during a build.