### PR TITLE
JDK-8212060: Fix Window show and then move glitch.

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1343,7 +1343,12 @@ void WindowContextTop::exit_fullscreen() {
 }
 
 void WindowContextTop::request_focus() {
-    gtk_window_present(GTK_WINDOW(gtk_widget));
+    //JDK-8212060: Window show and then move glitch.
+    //The WindowContextBase::set_visible will take care of showing the window.
+    //The below code will only handle later request_focus.
+    if (is_visible()) {
+        gtk_window_present(GTK_WINDOW(gtk_widget));
+    }
 }
 
 void WindowContextTop::set_focusable(bool focusable) {


### PR DESCRIPTION
This fixes the show and move glitch.

Explanation here:
https://mail.openjdk.java.net/pipermail/openjfx-dev/2019-April/023234.html

OCA pending.