### PR TITLE
WIP: JDK-8179462: Remove obsolete -XDignore.symbol.file flag from FX javadoc build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3962,7 +3962,6 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     } else {
         options.links(JDK_DOCS);
     }
-    options.addBooleanOption("XDignore.symbol.file").setValue(true);
     options.addBooleanOption("Xdoclint:${DOC_LINT}").setValue(IS_DOC_LINT);
     options.addBooleanOption("html5").setValue(true);
     options.addBooleanOption("javafx").setValue(true);


### PR DESCRIPTION
[JDK-8179462](https://bugs.openjdk.java.net/browse/JDK-8179462)

Simple fix to remove an obsolete command line option from our javadoc build.
