### PR TITLE
JDK-8197536: TableView, ListView: unexpected scrolling behaviour on up/down keys

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1459,10 +1459,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             scrollTo(cell);
         } else {
             // see JDK-8197536
-            if (tryScrollOneCell(index, true))
+            if (tryScrollOneCell(index, true)) {
                 return;
-            else if (tryScrollOneCell(index, false))
+            } else if (tryScrollOneCell(index, false)) {
                 return;
+            }
 
             adjustPositionToIndex(index);
             addAllToPile();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1471,25 +1471,26 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     }
 
     // will return true if scroll is successful
-    private boolean tryScrollOneUpOrDown(int targetIndex, boolean down) {
+    private boolean tryScrollOneUpOrDown(int targetIndex, boolean downOrRight) {
         // if going down, cell diff is -1, because it will get the target cell index and check if previous
         // cell is visible to base the position
-        int indexDiff = down ? -1 : 1;
+        int indexDiff = downOrRight ? -1 : 1;
 
-        T next = getVisibleCell(targetIndex + indexDiff);
-        if (next != null) {
+        T targetCell = getVisibleCell(targetIndex + indexDiff);
+        if (targetCell != null) {
             T cell = getAvailableCell(targetIndex);
             setCellIndex(cell, targetIndex);
-            resizeCell(cell); // resize must be after config
-            if (down) {
-                cells.addLast(cell);
-            } else {
-                cells.addFirst(cell);
-            }
-            positionCell(cell, getCellPosition(next) + (getCellLength(cell) * indexDiff * -1));
+            resizeCell(cell);
             setMaxPrefBreadth(Math.max(getMaxPrefBreadth(), getCellBreadth(cell)));
             cell.setVisible(true);
-            scrollTo(cell);
+            if (downOrRight) {
+                cells.addLast(cell);
+                scrollPixels(getCellLength(cell));
+            } else {
+                // up or left
+                cells.addFirst(cell);
+                scrollPixels(-getCellLength(cell));
+            }
             return true;
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1458,8 +1458,8 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         if (cell != null) {
             scrollTo(cell);
         } else {
-            //see JDK-8197536
-            if(tryScrollOneUpOrDown(index, true))
+            // see JDK-8197536
+            if (tryScrollOneUpOrDown(index, true))
                 return;
             else if (tryScrollOneUpOrDown(index, false))
                 return;
@@ -1470,18 +1470,18 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         }
     }
 
-    //will return true if scroll is successful
+    // will return true if scroll is successful
     private boolean tryScrollOneUpOrDown(int targetIndex, boolean down) {
-        //if going down, cell diff is -1, because it will get the target cell index and check if previous
-        //cell is visible to base the position
-        int indexDiff = (down) ? -1 : 1;
+        // if going down, cell diff is -1, because it will get the target cell index and check if previous
+        // cell is visible to base the position
+        int indexDiff = down ? -1 : 1;
 
         T next = getVisibleCell(targetIndex + indexDiff);
         if (next != null) {
             T cell = getAvailableCell(targetIndex);
             setCellIndex(cell, targetIndex);
             resizeCell(cell); // resize must be after config
-            if(down) {
+            if (down) {
                 cells.addLast(cell);
             } else {
                 cells.addFirst(cell);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1459,9 +1459,9 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             scrollTo(cell);
         } else {
             // see JDK-8197536
-            if (tryScrollOneUpOrDown(index, true))
+            if (tryScrollOneCell(index, true))
                 return;
-            else if (tryScrollOneUpOrDown(index, false))
+            else if (tryScrollOneCell(index, false))
                 return;
 
             adjustPositionToIndex(index);
@@ -1471,7 +1471,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     }
 
     // will return true if scroll is successful
-    private boolean tryScrollOneUpOrDown(int targetIndex, boolean downOrRight) {
+    private boolean tryScrollOneCell(int targetIndex, boolean downOrRight) {
         // if going down, cell diff is -1, because it will get the target cell index and check if previous
         // cell is visible to base the position
         int indexDiff = downOrRight ? -1 : 1;

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -52,6 +52,11 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
     }
 
     @Override
+    public double getCellPosition(T cell) {
+        return super.getCellPosition(cell);
+    }
+
+    @Override
     public void recreateCells() {
         super.recreateCells();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1127,9 +1127,8 @@ public class VirtualFlowTest {
         assertEquals(flow.getViewportLength()-25.0, VirtualFlowShim.<IndexedCell>cells_getLast(flow.cells).getLayoutY(), 0.0);
     }
 
-    @Test
-    // see JDK-8197536
-    public void testScrollOneCell() {
+    private void assertLastCellInsideViewport(boolean vertical) {
+        flow.setVertical(vertical);
         flow.resize(400, 400);
 
         int total = 10000;
@@ -1160,9 +1159,14 @@ public class VirtualFlowTest {
 
     @Test
     // see JDK-8197536
+    public void testScrollOneCell() {
+        assertLastCellInsideViewport(true);
+    }
+
+    @Test
+    // see JDK-8197536
     public void testScrollOneCellHorizontal() {
-        flow.setVertical(false);
-        testScrollOneCell();
+        assertLastCellInsideViewport(false);
     }
 }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1126,6 +1126,44 @@ public class VirtualFlowTest {
         assertMinimalNumberOfCellsAreUsed(flow);
         assertEquals(flow.getViewportLength()-25.0, VirtualFlowShim.<IndexedCell>cells_getLast(flow.cells).getLayoutY(), 0.0);
     }
+
+    @Test
+    // see JDK-8197536
+    public void testScrollOneCell() {
+        flow.resize(400, 400);
+
+        int total = 10000;
+        flow.setCellCount(total);
+        pulse();
+
+        int count = 9000;
+        flow.setPosition(0d);
+        pulse();
+        flow.setPosition(((double)count) / total);
+        pulse();
+
+        //simulate 500 right key strokes
+        for (int i = 0; i < 500; i++) {
+            count++;
+            flow.scrollTo(count);
+            pulse();
+        }
+
+        IndexedCell vc = flow.getCell(count);
+
+        double cellPosition = flow.getCellPosition(vc);
+        double cellLength = flow.getCellLength(count);
+        double viewportLength = flow.getViewportLength();
+
+        assertEquals("Last cell must end on viewport size", viewportLength, (cellPosition + cellLength), 0.1);
+    }
+
+    @Test
+    // see JDK-8197536
+    public void testScrollOneCellHorizontal() {
+        flow.setVertical(false);
+        testScrollOneCell();
+    }
 }
 
 class CellStub extends IndexedCellShim {


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8197536

As pointed out in the bug it was introduced when VirtualFlow moved to the public scope. There was a special case for scrolling up/down one cell that was removed.

This fix restores the special case, that is more precise than the 0 to 1 relative position on the virtual flow.

The 0 to 1 (0% to 100%) position of the vertical scroll is not cell height precise, so the special case is needed for "move one cell up" ou "move one cell down". (specially with long lists).

Is a test case doable?
