### PR TITLE
Add SANDBOX-FILES.md to list the set of "sandbox-only" files.

### DIFF
--- a/SANDBOX-FILES.md
+++ b/SANDBOX-FILES.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This file contains a list of the few "sandbox-only" file in this repo. The
+This file contains a list of the few "sandbox-only" files in this repo. The
 files in this list only exist in the `javafxports/openjdk-jfx` sandbox
 and are not in the upstream HG repo. This is a very minimal set of files
 limited primarily to "README" files that are unique to the sandbox and

--- a/SANDBOX-FILES.md
+++ b/SANDBOX-FILES.md
@@ -1,7 +1,7 @@
 # Introduction
 
 This file contains a list of the few "sandbox-only" file in this repo. The
-files in this list only exist in the javafxports/openjdk-jfx sandbox
+files in this list only exist in the `javafxports/openjdk-jfx` sandbox
 and are not in the upstream HG repo. This is a very minimal set of files
 limited primarily to "README" files that are unique to the sandbox and
 Continuous Integration (CI) test scripts. Over time we expect this set
@@ -9,15 +9,15 @@ of files to shrink.
 
 As a reminder, the general policy for making updates is:
 
-1. A PR that touches "sandbox-only" files must only modify "sandbox-only"
+1. A PR that touches "sandbox-only" files must _only_ modify "sandbox-only"
 files. You can't mix "sandbox-only" files and upstream managed files in
 the same PR.
 
-2. After a PR that touches "sandbox-only" files is merged into develop,
-it will need to be manually integrated into master as well by one of
+2. After a PR that touches "sandbox-only" files is merged into `develop`,
+it will need to be manually integrated into `master` as well by one of
 the sandbox maintainers.
 
-# List of javafxports-only files
+# List of sandbox-only files
 
 ```
 .ci/before_install.sh

--- a/SANDBOX-FILES.md
+++ b/SANDBOX-FILES.md
@@ -1,0 +1,33 @@
+# Introduction
+
+This file contains a list of the few "sandbox-only" file in this repo. The
+files in this list only exist in the javafxports/openjdk-jfx sandbox
+and are not in the upstream HG repo. This is a very minimal set of files
+limited primarily to "README" files that are unique to the sandbox and
+Continuous Integration (CI) test scripts. Over time we expect this set
+of files to shrink.
+
+As a reminder, the general policy for making updates is:
+
+1. A PR that touches "sandbox-only" files must only modify "sandbox-only"
+files. You can't mix "sandbox-only" files and upstream managed files in
+the same PR.
+
+2. After a PR that touches "sandbox-only" files is merged into develop,
+it will need to be manually integrated into master as well by one of
+the sandbox maintainers.
+
+# List of javafxports-only files
+
+```
+.ci/before_install.sh
+.ci/script.sh
+.github/CONTRIBUTING.md
+.github/README.md
+.github/pr-check-whitespace.sh
+.github/pr-list-files.sh
+.github/sync_upstream.sh
+.travis.yml
+SANDBOX-FILES.md
+appveyor.yml
+```


### PR DESCRIPTION
As indicated by the title of this PR, this adds a new file which contains a list of files that are in the `master` and `develop` branches of the `javafxports/openjdk-jfx` sandbox repo, but are not in the upstream [hg.openjdk.java.net/openjfx/jfx-dev/rt](https://hg.openjdk.java.net/openjfx/jfx-dev/rt) HG repo. This new file, `SANDBOX-FILES.md`, is itself in the list.
