### PR TITLE
JDK-8223377: JavaFX can crash due to loading the wrong native libraries if system libraries are installed

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -116,7 +116,7 @@ public class NativeLibLoader {
         //   (only on non-modular builds)
         // - if the native library comes bundled as a resource it is extracted
         //   and loaded
-        // - the jna.library.path is searched for the library in definition
+        // - the java.library.path is searched for the library in definition
         //   order
         // - the library is loaded via System#loadLibrary
         // - on iOS native library is staticly linked and detected from the

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -111,9 +111,16 @@ public class NativeLibLoader {
     }
 
     private static void loadLibraryInternal(String libraryName, List<String> dependencies, Class caller) {
-        // Look for the library in the same directory as the jar file
-        // containing this class.
-        // If that fails, then try System.loadLibrary.
+        // The search order for native library loading is:
+        // - try to load the native library from the same folder as this jar
+        //   (only on non-modular builds)
+        // - if the native library comes bundled as a resource it is extracted
+        //   and loaded
+        // - the jna.library.path is searched for the library in definition
+        //   order
+        // - the library is loaded via System#loadLibrary
+        // - on iOS native library is staticly linked and detected from the
+        //   existence of a JNI_OnLoad_libraryname funtion
         try {
             // FIXME: JIGSAW -- We should eventually remove this legacy path,
             // since it isn't applicable to Jigsaw.
@@ -121,6 +128,11 @@ public class NativeLibLoader {
         } catch (UnsatisfiedLinkError ex) {
             if (verbose && !usingModules) {
                 System.err.println("WARNING: " + ex);
+            }
+
+            // if the library is available in the jar, copy it to cache and load it from there
+            if (loadLibraryFromResource(libraryName, dependencies, caller)) {
+                return;
             }
 
             // NOTE: First attempt to load the libraries from the java.library.path.
@@ -153,10 +165,6 @@ public class NativeLibLoader {
                             + libraryName + ") succeeded");
                 }
             } catch (UnsatisfiedLinkError ex2) {
-                // if the library is available in the jar, copy it to cache and load it from there
-                if (loadLibraryFromResource(libraryName, dependencies, caller)) {
-                    return;
-                }
                 //On iOS we link all libraries staticaly. Presence of library
                 //is recognized by existence of JNI_OnLoad_libraryname() C function.
                 //If libraryname contains hyphen, it needs to be translated


### PR DESCRIPTION
This is an attempt to implement the change of the load order
of the native libraries as described in JDK-8223377.

The first commit refactors the library loading code into distinct
methods per loading variant. That commit does not change the
behavior of the library loading. Based on the refactored method,
the second commit implements to reordering.

For the legal part: I have an OCA on file