### PR TITLE
Fixed unmatched quotation marks in javadoc

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
@@ -58,7 +58,7 @@ import javafx.util.Callback;
  * StackPane example:
  * <pre>{@code
  *     StackPane stack = new StackPane();
- *     stack.getChildren().addAll(new Rectangle(100,100,Color.BLUE), new Label("Go!));
+ *     stack.getChildren().addAll(new Rectangle(100,100,Color.BLUE), new Label("Go!"));
  * }</pre>
  * <p>
  * StackPane lays out each managed child regardless of the child's


### PR DESCRIPTION
Changed from `new Label("Go!)` to `new Label("Go!")` in javadoc for StackPane