### PR TITLE
JDK-8222788: javafx.web build fails on XCode 10.2

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/Optional.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/Optional.h
@@ -277,14 +277,6 @@ struct nullopt_t
 constexpr nullopt_t nullopt{nullopt_t::init()};
 
 
-// 20.5.8, class bad_optional_access
-class bad_optional_access : public std::logic_error {
-public:
-  explicit bad_optional_access(const std::string& what_arg) : std::logic_error{what_arg} {}
-  explicit bad_optional_access(const char* what_arg) : std::logic_error{what_arg} {}
-};
-
-
 template <class T>
 union storage_t
 {


### PR DESCRIPTION
It is been already addressed in https://trac.webkit.org/changeset/235661.

We just need to cherry-pick the above changeset from upstream WebKit repo.

JBS link: https://bugs.openjdk.java.net/browse/JDK-8222788

It will address the issue #439 .