### PR TITLE
WIP: JDK-8226754: Fix gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1833,7 +1833,10 @@ allprojects {
         repositories {
             ivy {
                 url JFX_DEPS_URL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact]-[revision](-[classifier]).[ext]"
                     artifact "[artifact].[ext]"
                 }
@@ -1846,7 +1849,10 @@ allprojects {
             mavenCentral()
             ivy {
                 url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -1857,13 +1863,19 @@ allprojects {
         repositories {
             ivy {
                 url libAVRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
             ivy {
                 url FFmpegRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }

--- a/build.properties
+++ b/build.properties
@@ -85,7 +85,7 @@ jfx.build.jdk.buildnum.min=28
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
 jfx.gradle.version=5.3
-jfx.gradle.version.min=4.8
+jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc8.2.0-OL6.4+1.0

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,10 @@ repositories {
     if (buildClosed) {
         ivy {
             url jfxRepositoryURL
-            layout "pattern", {
+            metadataSources {
+                artifact()
+            }
+            patternLayout {
                 artifact "[artifact]-[revision].[ext]"
                 artifact "[artifact].[ext]"
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,10 +35,6 @@ project(":web").projectDir = file("modules/javafx.web")
 project(":media").projectDir = file("modules/javafx.media")
 project(":systemTests").projectDir = file("tests/system")
 
-// Stable publishing behavior is the default in gradle 5.x.
-// This setting enables it in gradle 4.8 to help with the transition.
-enableFeaturePreview('STABLE_PUBLISHING')
-
 def closedDir = file("../rt-closed")
 def buildClosed = closedDir.isDirectory()
 


### PR DESCRIPTION
JBS issue: [JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754)

As indicated in the JBS issue, we should fix the two gradle deprecation warnings we are getting with gradle 5.3.

This fix is as follows:

1. Remove the unnecessary `STABLE_PUBLISHING` setting
2. Use the incubating ivy `patternLayout(...)` method instead of `layout("pattern", ...)`
3. Bump minimum gradle version to 5.3 (the previous two changes will prevent it from running on gradle 4)

NOTE: Regarding 2, given that the recommended replacement, patternLayout(Action), is an incubating API, I propose to wait until there is a stable API to put this out for review.