### PR TITLE
8185937: Editable Spinner up/down keys do not increment/decrement

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
@@ -151,7 +151,7 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
      *                                                                         *
      **************************************************************************/
 
-    private boolean arrowsAreVertical() {
+    public boolean arrowsAreVertical() {
         final List<String> styleClass = getNode().getStyleClass();
 
         return ! (styleClass.contains(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_HORIZONTAL)  ||

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -185,6 +185,10 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
                 // Fix for RT-38527 which led to a stack overflow
                 if (ke.getCode() == KeyCode.ESCAPE) return;
 
+                // This and the additional check of isIncDecKeyEvent in
+                // textField's event filter fix JDK-8185937.
+                if (isIncDecKeyEvent(ke)) return;
+
                 // Fix for the regression noted in a comment in RT-29885.
                 // This forwards the event down into the TextField when
                 // the key event is actually received by the Spinner.
@@ -202,7 +206,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
         // work when you click inside the TextField area (but they do in the case
         // of tabbing in).
         textField.addEventFilter(KeyEvent.ANY, ke -> {
-            if (! control.isEditable()) {
+            if (! control.isEditable() || isIncDecKeyEvent(ke)) {
                 control.fireEvent(ke.copyFor(control, control));
                 ke.consume();
             }
@@ -247,7 +251,10 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
         }));
     }
 
-
+    private boolean isIncDecKeyEvent(KeyEvent ke) {
+        final KeyCode kc = ke.getCode();
+        return (kc == KeyCode.UP || kc == KeyCode.DOWN) && behavior.arrowsAreVertical();
+    }
 
     /***************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1429,7 +1429,7 @@ public class SpinnerTest {
         assertEquals(400.0, spinner.getInitialDelay().toMillis(), 0.001);
         assertEquals(100.0, spinner.getRepeatDelay().toMillis(), 0.001);
     }
-    
+
     // Test for JDK-8185937
     @Test public void testIncDecKeys() {
         Toolkit tk = (StubToolkit)Toolkit.getToolkit();
@@ -1439,7 +1439,7 @@ public class SpinnerTest {
         stage.setScene(scene);
         stage.setWidth(200);
         stage.setHeight(200);
-        
+
         Spinner<Integer> spinner = new Spinner<>(-100, 100, 0);
         spinner.setEditable(true);
         assertEquals(0, spinner.getValue().intValue());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1429,4 +1429,39 @@ public class SpinnerTest {
         assertEquals(400.0, spinner.getInitialDelay().toMillis(), 0.001);
         assertEquals(100.0, spinner.getRepeatDelay().toMillis(), 0.001);
     }
+    
+    // Test for JDK-8185937
+    @Test public void testIncDecKeys() {
+        Toolkit tk = (StubToolkit)Toolkit.getToolkit();
+        VBox root = new VBox();
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.setWidth(200);
+        stage.setHeight(200);
+        
+        Spinner<Integer> spinner = new Spinner<>(-100, 100, 0);
+        spinner.setEditable(true);
+        assertEquals(0, spinner.getValue().intValue());
+
+        try {
+            root.getChildren().addAll(spinner);
+            stage.show();
+            spinner.requestFocus();
+            tk.firePulse();
+
+            KeyEventFirer keyboard = new KeyEventFirer(spinner.getEditor());
+            keyboard.doKeyPress(KeyCode.UP);
+            tk.firePulse();
+
+            assertEquals(1, spinner.getValue().intValue());
+
+            keyboard.doKeyPress(KeyCode.DOWN);
+            tk.firePulse();
+
+            assertEquals(0, spinner.getValue().intValue());
+        } finally {
+            stage.hide();
+        }
+    }
 }


### PR DESCRIPTION
Added basic check for up/down keys in the KeyEvent filters when Spinner behaviour indicates the arrows are vertical.  Had to make a private method in SpinnerBehavior public to keep the vertical arrow check in one spot.