### PR TITLE
JDK-8227367 Add missing @Override's and fix static usage.

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -308,6 +308,7 @@ class D3DContext extends BaseShaderContext {
         validate(res);
     }
 
+    @Override
     protected void updateWorldTransform(BaseTransform xform) {
         if ((xform == null) || xform.isIdentity()) {
             nSetWorldTransformToIdentity(pContext);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
@@ -65,6 +65,7 @@ class D3DGraphics extends BaseShaderGraphics implements D3DContextSource {
         return new D3DGraphics(context, target);
     }
 
+    @Override
     public void clearQuad(float x1, float y1, float x2, float y2) {
         // note that unlike clear(), this method does not currently
         // attempt to clear the depth buffer...
@@ -82,18 +83,21 @@ class D3DGraphics extends BaseShaderGraphics implements D3DContextSource {
         setCompositeMode(oldMode);
     }
 
+    @Override
     public void clear(Color color) {
         context.validateClearOp(this);
         this.getRenderTarget().setOpaque(color.isOpaque());
         int res = nClear(context.getContextHandle(),
                           color.getIntArgbPre(), isDepthBuffer(), false);
-        context.validate(res);
+        D3DContext.validate(res);
     }
 
+    @Override
     public void sync() {
         context.flushVertexBuffer();
     }
 
+    @Override
     public D3DContext getContext() {
         return context;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
@@ -59,6 +59,7 @@ class D3DMesh extends BaseMesh {
         count--;
     }
 
+    @Override
     public int getCount() {
         return count;
     }
@@ -87,9 +88,9 @@ class D3DMesh extends BaseMesh {
             this.nativeHandle = nativeHandle;
         }
 
-         void traceDispose() {
-        }
+        void traceDispose() {}
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
@@ -117,9 +117,9 @@ class D3DMeshView extends BaseMeshView {
             this.nativeHandle = nativeHandle;
         }
 
-        void traceDispose() {
-        }
+        void traceDispose() {}
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
@@ -71,6 +71,7 @@ class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         context.setSpecularColor(nativeHandle, set, r, g, b, a);
     }
 
+    @Override
     public void setTextureMap(TextureMap map) {
         maps[map.getType().ordinal()] = map;
     }
@@ -84,6 +85,7 @@ class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         return texture;
     }
 
+    @Override
     public void lockTextureMaps() {
         for (int i = 0; i < MAX_MAP_TYPE; i++) {
             Texture texture = maps[i].getTexture();
@@ -106,6 +108,7 @@ class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         }
     }
 
+    @Override
     public void unlockTextureMaps() {
         for (int i = 0; i < MAX_MAP_TYPE; i++) {
             Texture texture = maps[i].getTexture();
@@ -135,9 +138,9 @@ class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
             this.nativeHandle = nativeHandle;
         }
 
-        void traceDispose() {
-        }
+        void traceDispose() {}
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -134,6 +134,7 @@ public final class D3DPipeline extends GraphicsPipeline {
     private D3DPipeline() {
     }
 
+    @Override
     public boolean init() {
         return d3dEnabled;
     }
@@ -234,6 +235,7 @@ public final class D3DPipeline extends GraphicsPipeline {
         return _default;
     }
 
+    @Override
     public ResourceFactory getResourceFactory(Screen screen) {
         return getD3DResourceFactory(screen.getAdapterOrdinal(), screen);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
@@ -65,22 +65,27 @@ class D3DRTTexture extends D3DTexture
         this.opaque = false;
     }
 
+    @Override
     public Texture getBackBuffer() {
         return this;
     }
 
+    @Override
     public long getResourceHandle() {
         return resource.getResource().getResource();
     }
 
+    @Override
     public Graphics createGraphics() {
         return D3DGraphics.create(this, getContext());
     }
 
+    @Override
     public int[] getPixels() {
         return null;
     }
 
+    @Override
     public boolean readPixels(Buffer pixels, int x, int y, int width, int height) {
         if (x != getContentX() || y != getContentY()
                 || width != getContentWidth() || height != getContentHeight())
@@ -90,6 +95,7 @@ class D3DRTTexture extends D3DTexture
         return readPixels(pixels);
     }
 
+    @Override
     public boolean readPixels(Buffer pixels) {
         getContext().flushVertexBuffer();
         long ctx = getContext().getContextHandle();
@@ -116,6 +122,7 @@ class D3DRTTexture extends D3DTexture
         return getContext().validatePresent(res);
     }
 
+    @Override
     public Screen getAssociatedScreen() {
         return getContext().getAssociatedScreen();
     }
@@ -149,18 +156,22 @@ class D3DRTTexture extends D3DTexture
         throw new UnsupportedOperationException("update() not supported for RTTextures");
     }
 
+    @Override
     public void setOpaque(boolean isOpaque) {
         this.opaque = isOpaque;
     }
 
+    @Override
     public boolean isOpaque() {
         return opaque;
     }
 
+    @Override
     public boolean isVolatile() {
         return getContext().isRTTVolatile();
     }
 
+    @Override
     public boolean isMSAA() {
         return resource.getResource().getSamples() != 0;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResource.java
@@ -109,6 +109,7 @@ class D3DResource extends BaseGraphicsResource {
             pResource = 0L;
         }
 
+        @Override
         public void dispose() {
             if (pResource != 0L) {
                 context.getResourceFactory().removeRecord(this);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -90,6 +90,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         return context;
     }
 
+    @Override
     public TextureResourcePool getTextureResourcePool() {
         return D3DVramPool.instance;
     }
@@ -241,6 +242,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         }
     }
 
+    @Override
     public int getRTTWidth(int w, WrapMode wrapMode) {
         // D3DRTTexture returns the requested dimension as the content dimension
         // so the answer here is just "w" despite the fact that a pow2 adjustment
@@ -253,6 +255,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         return w;
     }
 
+    @Override
     public int getRTTHeight(int h, WrapMode wrapMode) {
         // D3DRTTexture returns the requested dimension as the content dimension
         // so the answer here is just "h" despite the fact that a pow2 adjustment
@@ -317,6 +320,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         return rtt;
     }
 
+    @Override
     public Presentable createPresentable(PresentableState pState) {
         if (PrismSettings.verbose && context.isLost()) {
             System.err.println("SwapChain allocation while the device is lost");
@@ -379,6 +383,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         }
     }
 
+    @Override
     public Shader createShader(InputStream pixelShaderCode,
                                Map<String, Integer> samplers,
                                Map<String, Integer> params,
@@ -393,6 +398,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         return new D3DShader(context, shaderHandle, params);
     }
 
+    @Override
     public Shader createStockShader(final String name) {
         if (name == null) {
             throw new IllegalArgumentException("Shader name must be non-null");
@@ -470,15 +476,17 @@ class D3DResourceFactory extends BaseShaderFactory {
         records.remove(record);
     }
 
+    @Override
     public PhongMaterial createPhongMaterial() {
         return D3DPhongMaterial.create(context);
     }
 
+    @Override
     public MeshView createMeshView(Mesh mesh) {
         return D3DMeshView.create(context, (D3DMesh) mesh);
-
     }
 
+    @Override
     public Mesh createMesh() {
         return D3DMesh.create(context);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -442,6 +442,7 @@ class D3DResourceFactory extends BaseShaderFactory {
         return size;
     }
 
+    @Override
     public int getMaximumTextureSize() {
         return maxTextureSize;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DShader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DShader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DShader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DShader.java
@@ -59,19 +59,21 @@ final class D3DShader extends D3DResource implements Shader {
 
     private static native int nGetRegister(long pCtx, long pData, String name);
 
+    @Override
     public void enable() {
         // res >= 0 is equivalent to D3D's SUCCEEDED(res) macro
         int res = enable(d3dResRecord.getContext().getContextHandle(),
                           d3dResRecord.getResource());
         valid &= res >= 0;
-        d3dResRecord.getContext().validate(res);
+        D3DContext.validate(res);
     }
 
+    @Override
     public void disable() {
         int res = disable(d3dResRecord.getContext().getContextHandle(),
                            d3dResRecord.getResource());
         valid &= res >= 0;
-        d3dResRecord.getContext().validate(res);
+        D3DContext.validate(res);
     }
 
     private static void checkTmpIntBuf() {
@@ -81,6 +83,7 @@ final class D3DShader extends D3DResource implements Shader {
         itmp.clear();
     }
 
+    @Override
     public void setConstant(String name, int i0) {
         // NOTE: see HLSLBackend for an explanation of why we're using
         // floats here instead of ints...
@@ -92,6 +95,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstant(name, (float)i0);
     }
 
+    @Override
     public void setConstant(String name, int i0, int i1) {
         /*
         checkTmpIntBuf();
@@ -102,6 +106,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstant(name, (float)i0, (float)i1);
     }
 
+    @Override
     public void setConstant(String name, int i0, int i1, int i2) {
         /*
         checkTmpIntBuf();
@@ -113,6 +118,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstant(name, (float)i0, (float)i1, (float)i2);
     }
 
+    @Override
     public void setConstant(String name, int i0, int i1, int i2, int i3) {
         /*
         checkTmpIntBuf();
@@ -125,6 +131,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstant(name, (float)i0, (float)i1, (float)i2, (float)i3);
     }
 
+    @Override
     public void setConstants(String name, IntBuffer buf, int off, int count) {
         // NOTE: see HLSLBackend for an explanation of why we need to use
         // floats instead of ints; for now this codepath is disabled...
@@ -139,12 +146,14 @@ final class D3DShader extends D3DResource implements Shader {
         ftmp.clear();
     }
 
+    @Override
     public void setConstant(String name, float f0) {
         checkTmpFloatBuf();
         ftmp.put(f0);
         setConstants(name, ftmp, 0, 1);
     }
 
+    @Override
     public void setConstant(String name, float f0, float f1) {
         checkTmpFloatBuf();
         ftmp.put(f0);
@@ -152,6 +161,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstants(name, ftmp, 0, 1);
     }
 
+    @Override
     public void setConstant(String name, float f0, float f1, float f2) {
         checkTmpFloatBuf();
         ftmp.put(f0);
@@ -160,6 +170,7 @@ final class D3DShader extends D3DResource implements Shader {
         setConstants(name, ftmp, 0, 1);
     }
 
+    @Override
     public void setConstant(String name, float f0, float f1, float f2, float f3) {
         checkTmpFloatBuf();
         ftmp.put(f0);
@@ -169,12 +180,13 @@ final class D3DShader extends D3DResource implements Shader {
         setConstants(name, ftmp, 0, 1);
     }
 
+    @Override
     public void setConstants(String name, FloatBuffer buf, int off, int count) {
             int res = setConstantsF(d3dResRecord.getContext().getContextHandle(),
                                      d3dResRecord.getResource(),
                                      getRegister(name), buf, off, count);
             valid &= res >= 0;
-            d3dResRecord.getContext().validate(res);
+            D3DContext.validate(res);
     }
 
     private int getRegister(String name) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -78,46 +78,56 @@ class D3DSwapChain
         return true;
     }
 
+    @Override
     public boolean present() {
         D3DContext context = getContext();
         int res = nPresent(context.getContextHandle(), d3dResRecord.getResource());
         return context.validatePresent(res);
     }
 
+    @Override
     public long getResourceHandle() {
         return d3dResRecord.getResource();
     }
 
+    @Override
     public int getPhysicalWidth() {
         return D3DResourceFactory.nGetTextureWidth(d3dResRecord.getResource());
     }
 
+    @Override
     public int getPhysicalHeight() {
         return D3DResourceFactory.nGetTextureHeight(d3dResRecord.getResource());
     }
 
+    @Override
     public int getContentWidth() {
         return getPhysicalWidth();
     }
 
+    @Override
     public int getContentHeight() {
         return getPhysicalHeight();
     }
 
+    @Override
     public int getContentX() {
         return 0;
     }
 
+    @Override
     public int getContentY() {
         return 0;
     }
 
     private static native int nPresent(long context, long pSwapChain);
 
+    @Override
     public D3DContext getContext() {
         return d3dResRecord.getContext();
     }
 
+    @Override
     public boolean lockResources(PresentableState pState) {
         if (pState.getRenderWidth() != texBackBuffer.getContentWidth() ||
             pState.getRenderHeight() != texBackBuffer.getContentHeight() ||
@@ -140,6 +150,7 @@ class D3DSwapChain
         return texBackBuffer;
     }
 
+    @Override
     public Screen getAssociatedScreen() {
         return getContext().getAssociatedScreen();
     }
@@ -154,14 +165,17 @@ class D3DSwapChain
         return pixelScaleFactorY;
     }
 
+    @Override
     public boolean isOpaque() {
         return texBackBuffer.isOpaque();
     }
 
+    @Override
     public void setOpaque(boolean opaque) {
         texBackBuffer.setOpaque(opaque);
     }
 
+    @Override
     public boolean isMSAA() {
         return texBackBuffer != null ? texBackBuffer.isMSAA() : false;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -140,6 +140,7 @@ class D3DSwapChain
         return texBackBuffer.isSurfaceLost();
     }
 
+    @Override
     public Graphics createGraphics() {
         Graphics g = D3DGraphics.create(texBackBuffer, getContext());
         g.scale(pixelScaleFactorX, pixelScaleFactorY);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
@@ -84,6 +84,7 @@ class D3DTexture extends BaseTexture<D3DTextureResource>
         return resource.getResource().getContext();
     }
 
+    @Override
     public void update(MediaFrame frame, boolean skipFlush)
     {
         if (frame.getPixelFormat() == PixelFormat.MULTI_YCbCr_420) {
@@ -92,7 +93,7 @@ class D3DTexture extends BaseTexture<D3DTextureResource>
         }
         frame.holdFrame();
 
-        ByteBuffer pixels = (ByteBuffer)frame.getBufferForPlane(0);
+        ByteBuffer pixels = frame.getBufferForPlane(0);
         int result;
 
         // FIXME: checkVideoParams since they differ from normal params slightly
@@ -128,6 +129,7 @@ class D3DTexture extends BaseTexture<D3DTextureResource>
         frame.releaseFrame();
     }
 
+    @Override
     public void update(Buffer pixels, PixelFormat format,
                        int dstx, int dsty,
                        int srcx, int srcy,

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DTexture.java
@@ -80,6 +80,7 @@ class D3DTexture extends BaseTexture<D3DTextureResource>
         return D3DResourceFactory.nGetNativeTextureObject(getNativeSourceHandle());
     }
 
+    @Override
     public D3DContext getContext() {
         return resource.getResource().getContext();
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
@@ -57,6 +57,7 @@ public class ES2Graphics extends BaseShaderGraphics {
 
     }
 
+    @Override
     public void clearQuad(float x1, float y1, float x2, float y2) {
         // note that unlike clear(), this method does not currently
         // attempt to clear the depth buffer...
@@ -74,6 +75,7 @@ public class ES2Graphics extends BaseShaderGraphics {
         context.updateCompositeMode(mode);
     }
 
+    @Override
     public void clear(Color color) {
         context.validateClearOp(this);
         this.getRenderTarget().setOpaque(color.isOpaque());
@@ -81,6 +83,7 @@ public class ES2Graphics extends BaseShaderGraphics {
 
     }
 
+    @Override
     public void sync() {
         context.flushVertexBuffer();
         context.getGLContext().finish();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
@@ -87,9 +87,9 @@ class ES2Mesh extends BaseMesh {
             this.nativeHandle = nativeHandle;
         }
 
-        void traceDispose() {
-        }
+        void traceDispose() {}
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Mesh.java
@@ -59,6 +59,7 @@ class ES2Mesh extends BaseMesh {
         count--;
     }
 
+    @Override
     public int getCount() {
         return count;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
@@ -147,9 +147,9 @@ class ES2MeshView extends BaseMeshView {
             this.nativeHandle = nativeHandle;
         }
 
-        void traceDispose() {
-        }
+        void traceDispose() { }
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
@@ -77,6 +77,7 @@ class ES2PhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         specularColor = new Color(r,g,b,a);
     }
 
+    @Override
     public void setTextureMap(TextureMap map) {
         maps[map.getType().ordinal()] = map;
     }
@@ -88,6 +89,7 @@ class ES2PhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         return texture;
     }
 
+    @Override
     public void lockTextureMaps() {
         for (int i = 0; i < MAX_MAP_TYPE; i++) {
             Texture texture = maps[i].getTexture();
@@ -110,6 +112,7 @@ class ES2PhongMaterial extends BaseGraphicsResource implements PhongMaterial {
         }
     }
 
+    @Override
     public void unlockTextureMaps() {
         for (int i = 0; i < MAX_MAP_TYPE; i++ ) {
             Texture texture = maps[i].getTexture();
@@ -139,9 +142,9 @@ class ES2PhongMaterial extends BaseGraphicsResource implements PhongMaterial {
             this.nativeHandle = nativeHandle;
         }
 
-        void traceDispose() {
-        }
+        void traceDispose() {}
 
+        @Override
         public void dispose() {
             if (nativeHandle != 0L) {
                 traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2RTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2RTTexture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2RTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2RTTexture.java
@@ -304,18 +304,22 @@ class ES2RTTexture extends ES2Texture<ES2RTTextureData>
         return es2RTT;
     }
 
+    @Override
     public Texture getBackBuffer() {
         return this;
     }
 
+    @Override
     public Graphics createGraphics() {
         return ES2Graphics.create(context, this);
     }
 
+    @Override
     public int[] getPixels() {
         return null;
     }
 
+    @Override
     public boolean readPixels(Buffer pixels, int x, int y, int width, int height) {
         context.flushVertexBuffer();
         GLContext glContext = context.getGLContext();
@@ -332,15 +336,18 @@ class ES2RTTexture extends ES2Texture<ES2RTTextureData>
         return result;
     }
 
+    @Override
     public boolean readPixels(Buffer pixels) {
         return readPixels(pixels, getContentX(), getContentY(),
                  getContentWidth(), getContentHeight());
     }
 
+    @Override
     public int getFboID() {
         return resource.getResource().getFboID();
     }
 
+    @Override
     public Screen getAssociatedScreen() {
         return context.getAssociatedScreen();
     }
@@ -373,18 +380,22 @@ class ES2RTTexture extends ES2Texture<ES2RTTextureData>
         throw new UnsupportedOperationException("update() not supported for RTTextures");
     }
 
+    @Override
     public boolean isOpaque() {
         return opaque;
     }
 
+    @Override
     public void setOpaque(boolean opaque) {
         this.opaque = opaque;
     }
 
+    @Override
     public boolean isVolatile() {
         return false;
     }
 
+    @Override
     public boolean isMSAA() {
         return resource.getResource().getMSAARenderBufferID() != 0;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
@@ -93,10 +93,12 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         }
     }
 
+    @Override
     public TextureResourcePool getTextureResourcePool() {
         return ES2VramPool.instance;
     }
 
+    @Override
     public Presentable createPresentable(PresentableState pState) {
         return new ES2SwapChain(context, pState);
     }
@@ -123,6 +125,7 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         return context.getGLContext().canCreateNonPowTwoTextures();
     }
 
+    @Override
     public Texture createTexture(PixelFormat formatHint,
                                  Usage usageHint,
                                  WrapMode wrapMode,
@@ -137,26 +140,32 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         return ES2Texture.create(context, formatHint, wrapMode, w, h, useMipmap);
     }
 
+    @Override
     public Texture createTexture(MediaFrame frame) {
         return ES2Texture.create(context, frame);
     }
 
+    @Override
     public int getRTTWidth(int w, WrapMode wrapMode) {
         return ES2RTTexture.getCompatibleDimension(context, w, wrapMode);
     }
 
+    @Override
     public int getRTTHeight(int h, WrapMode wrapMode) {
         return ES2RTTexture.getCompatibleDimension(context, h, wrapMode);
     }
 
+    @Override
     public RTTexture createRTTexture(int width, int height, WrapMode wrapMode) {
         return createRTTexture(width, height, wrapMode, false);
     }
 
+    @Override
     public RTTexture createRTTexture(int width, int height, WrapMode wrapMode, boolean msaa) {
         return ES2RTTexture.create(context, width, height, wrapMode, msaa);
     }
 
+    @Override
     public boolean isFormatSupported(PixelFormat format) {
         GLFactory glFactory = ES2Pipeline.glFactory;
         switch (format) {
@@ -202,10 +211,12 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         return size;
     }
 
+    @Override
     public int getMaximumTextureSize() {
         return maxTextureSize;
     }
 
+    @Override
     public Shader createShader(InputStream pixelShaderCode,
             Map<String, Integer> samplers,
             Map<String, Integer> params,
@@ -293,6 +304,7 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         return attributes;
     }
 
+    @Override
     public Shader createStockShader(String name) {
         if (name == null) {
             throw new IllegalArgumentException("Shader name must be non-null");
@@ -316,18 +328,22 @@ public class ES2ResourceFactory extends BaseShaderFactory {
         }
     }
 
+    @Override
     public void dispose() {
         context.clearContext();
     }
 
+    @Override
     public PhongMaterial createPhongMaterial() {
         return ES2PhongMaterial.create(context);
 }
 
+    @Override
     public MeshView createMeshView(Mesh mesh) {
         return ES2MeshView.create(context, (ES2Mesh) mesh);
     }
 
+    @Override
     public Mesh createMesh() {
         return ES2Mesh.create(context);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Shader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Shader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Shader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Shader.java
@@ -243,6 +243,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void enable() throws RuntimeException {
         context.updateShaderProgram(programID);
     }
@@ -253,11 +254,13 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void disable() throws RuntimeException {
         // TODO: remove disable() method from Shader interface... (RT-27442)
         context.updateShaderProgram(0);
     }
 
+    @Override
     public boolean isValid() {
         return valid;
     }
@@ -271,6 +274,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, int i0)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -297,6 +301,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, int i0, int i1)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -325,6 +330,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, int i0, int i1, int i2)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -355,6 +361,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, int i0, int i1, int i2, int i3)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -383,6 +390,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, float f0)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -409,6 +417,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, float f0, float f1)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -437,6 +446,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, float f0, float f1, float f2)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -467,6 +477,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstant(String name, float f0, float f1, float f2, float f3)
             throws RuntimeException {
         Uniform uniform = getUniform(name);
@@ -497,6 +508,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstants(String name, IntBuffer buf, int off, int count)
             throws RuntimeException {
         // TODO: remove off param in favor of IntBuffer.position() (RT-27442)
@@ -519,6 +531,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void setConstants(String name, FloatBuffer buf, int off, int count)
             throws RuntimeException {
         int loc = getUniform(name).location;
@@ -547,7 +560,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
             currentMatrix = new float[GLContext.NUM_MATRIX_ELEMENTS];
         }
 
-        if (Arrays.equals(currentMatrix, buf) == false) {
+        if (!Arrays.equals(currentMatrix, buf)) {
             context.getGLContext().uniformMatrix4fv(loc, false, buf);
             System.arraycopy(buf, 0, currentMatrix, 0, buf.length);
         }
@@ -559,6 +572,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
      * @throws RuntimeException if no OpenGL context was current or if any
      * OpenGL-related errors occurred
      */
+    @Override
     public void dispose() throws RuntimeException {
         if (programID != 0) {
             disposerRecord.dispose();
@@ -584,6 +598,7 @@ public class ES2Shader extends BaseGraphicsResource implements Shader {
             this.programID = programID;
         }
 
+        @Override
         public void dispose() {
             if (programID != 0) {
                 context.getGLContext().disposeShaders(programID,

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -96,6 +96,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
                 nativeWindow, context.getPixelFormat());
     }
 
+    @Override
     public boolean lockResources(PresentableState pState) {
         if (this.pState != pState ||
             pixelScaleFactorX != pState.getRenderScaleX() ||
@@ -120,6 +121,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         return false;
     }
 
+    @Override
     public boolean prepare(Rectangle clip) {
         try {
             ES2Graphics g = ES2Graphics.create(context, this);
@@ -177,12 +179,14 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         g.setCompositeMode(savedMode);
     }
 
+    @Override
     public boolean present() {
         boolean presented = drawable.swapBuffers(context.getGLContext());
         context.makeCurrent(null);
         return presented;
     }
 
+    @Override
     public ES2Graphics createGraphics() {
         if (drawable.getNativeWindow() != pState.getNativeWindow()) {
             drawable = ES2Pipeline.glFactory.createGLDrawable(
@@ -229,22 +233,27 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         return g;
     }
 
+    @Override
     public int getFboID() {
         return nativeDestHandle;
     }
 
+    @Override
     public Screen getAssociatedScreen() {
         return context.getAssociatedScreen();
     }
 
+    @Override
     public int getPhysicalWidth() {
         return pState.getOutputWidth();
     }
 
+    @Override
     public int getPhysicalHeight() {
         return pState.getOutputHeight();
     }
 
+    @Override
     public int getContentX() {
         // EGL doesn't have a window manager, so we need to ask the window for
         // the x/y offset to use
@@ -255,6 +264,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
     }
 
+    @Override
     public int getContentY() {
         // EGL doesn't have a window manager, so we need to ask the window
         // for the x/y offset to use
@@ -266,10 +276,12 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
     }
 
+    @Override
     public int getContentWidth() {
         return pState.getOutputWidth();
     }
 
+    @Override
     public int getContentHeight() {
         return pState.getOutputHeight();
     }
@@ -292,6 +304,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
     }
 
+    @Override
     public boolean isMSAA() {
         return stableBackbuffer != null ? stableBackbuffer.isMSAA() :
                 msaa;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -69,6 +69,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
     private RTTexture stableBackbuffer;
     private boolean copyFullBuffer;
 
+    @Override
     public boolean isOpaque() {
         if (stableBackbuffer != null) {
             return stableBackbuffer.isOpaque();
@@ -77,6 +78,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
     }
 
+    @Override
     public void setOpaque(boolean isOpaque) {
         if (stableBackbuffer != null) {
             stableBackbuffer.setOpaque(isOpaque);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
@@ -631,6 +631,7 @@ class ES2Texture<T extends ES2TextureData> extends BaseTexture<ES2TextureResourc
         return resource.getResource().getTexID();
     }
 
+    @Override
     public void update(Buffer pixels, PixelFormat format,
             int dstx, int dsty,
             int srcx, int srcy,
@@ -752,6 +753,7 @@ class ES2Texture<T extends ES2TextureData> extends BaseTexture<ES2TextureResourc
         }
     }
 
+    @Override
     public void update(MediaFrame frame, boolean skipFlush) {
         if (!skipFlush) {
             context.flushVertexBuffer();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Texture.java
@@ -33,7 +33,6 @@ import com.sun.prism.MultiTexture;
 import com.sun.prism.PixelFormat;
 import com.sun.prism.impl.BaseTexture;
 import com.sun.prism.impl.BufferUtil;
-import com.sun.prism.impl.PrismSettings;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2TextureData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2TextureData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2TextureData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2TextureData.java
@@ -79,6 +79,7 @@ class ES2TextureData implements Disposer.Record {
         PrismTrace.textureDisposed(texID);
     }
 
+    @Override
     public void dispose() {
         if (texID != 0) {
             traceDispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,6 +102,8 @@ abstract class GLFactory {
         FactoryLoader(String factoryClassName) {
             this.factoryClassName = factoryClassName;
         }
+
+        @Override
         public GLFactory run() {
             GLFactory factory = null;
             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,6 @@ package com.sun.prism.es2;
 import java.lang.annotation.Native;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-
-import com.sun.glass.utils.NativeLibLoader;
-import com.sun.javafx.PlatformUtil;
-import com.sun.prism.impl.PrismSettings;
 
 class GLPixelFormat {
     final private Attributes attributes;
@@ -168,6 +164,7 @@ class GLPixelFormat {
             redSize = rs;
         }
 
+        @Override
         public String toString() {
             return "onScreen: " + onScreen
                     + "redSize : " + redSize + ", "


### PR DESCRIPTION
Very simple PR that adds missing `@Override` annotations to classes in `javafx.graphics/src/main/java/com/sun/prism/*`. This is always good practice but in this specific case it will help anyone trying to implement a new rendering pipeline (Vulkan, DirectX 11/12, etc.) as it makes it easier to see what methods are required to be implemented as they are used by Prism and which methods are implementation details.

I also took the liberty to fix a couple places where a static method was being called on an instance of a class and make the formatting of the empty `traceDispose` methods consistent (putting opening and closing curly brackets on same line).