### PR TITLE
JDK-8226365: Change JavaFX release version to 14

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=13
+jfx.release.major.version=14
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2019, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 13
-javadoc.header=JavaFX&nbsp;13
+javadoc.title=JavaFX 14
+javadoc.header=JavaFX&nbsp;14
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("13"));
+        assertTrue(version.startsWith("14"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
[JDK-8226365](https://bugs.openjdk.java.net/browse/JDK-8226365)

The JavaFX 13-dev repo will be forked from jfx-dev tomorrow morning, after which, we need to bump the release version to 14. As such, I will wait until tomorrow to send out the formal RFR and remove the WIP label.
