### PR TITLE
JDK-8222912: Websocket client doesn't work in WebView

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
@@ -1922,7 +1922,7 @@ platform/network/ResourceRequestBase.cpp
 platform/network/ResourceResponseBase.cpp
 platform/network/SameSiteInfo.cpp
 platform/network/SocketStreamHandle.cpp
-// platform/network/SocketStreamHandleImpl.cpp
+platform/network/SocketStreamHandleImpl.cpp
 platform/network/SynchronousLoaderClient.cpp
 
 platform/sql/SQLiteAuthorizer.cpp

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -113,6 +113,9 @@ public:
     WEBCORE_EXPORT void setCookieDatabase(UniqueRef<CookieJarDB>&&);
 
     WEBCORE_EXPORT void setProxySettings(CurlProxySettings&&);
+#elif PLATFORM(JAVA)
+    WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID);
+    ~NetworkStorageSession();
 #else
     WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID, NetworkingContext*);
     ~NetworkStorageSession();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/NetworkStorageSessionJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/NetworkStorageSessionJava.cpp
@@ -27,6 +27,7 @@
 #include "NetworkStorageSession.h"
 
 #include "Cookie.h"
+#include "CookieRequestHeaderFieldProxy.h"
 #include "NetworkingContext.h"
 #include "NotImplemented.h"
 #include "ResourceHandle.h"
@@ -82,19 +83,13 @@ static String getCookies(const URL& url, bool includeHttpOnlyCookies)
 }
 }
 
-NetworkStorageSession::NetworkStorageSession(PAL::SessionID sessionID, NetworkingContext* context)
+NetworkStorageSession::NetworkStorageSession(PAL::SessionID sessionID)
     : m_sessionID(sessionID)
-    , m_context(context)
 {
 }
 
 NetworkStorageSession::~NetworkStorageSession()
 {
-}
-
-NetworkingContext* NetworkStorageSession::context() const
-{
-    return m_context.get();
 }
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& /*firstParty*/, const SameSiteInfo&, const URL& url, Optional<uint64_t>, Optional<uint64_t>, const String& value) const
@@ -120,6 +115,11 @@ std::pair<String, bool> NetworkStorageSession::cookiesForDOM(const URL&, const S
 std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(const URL& /*firstParty*/, const SameSiteInfo&, const URL& url, Optional<uint64_t>, Optional<uint64_t>, IncludeSecureCookies) const
 {
     return { CookieInternalJava::getCookies(url, true), true };
+}
+
+std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(const CookieRequestHeaderFieldProxy& headerFieldProxy) const
+{
+    return { CookieInternalJava::getCookies(headerFieldProxy.firstParty, true), true };
 }
 
 bool NetworkStorageSession::cookiesEnabled() const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImpl.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImpl.h
@@ -37,6 +37,7 @@
 #include <pal/SessionID.h>
 #include <wtf/java/JavaRef.h>
 #include <wtf/RefCounted.h>
+#include <wtf/StreamBuffer.h>
 
 namespace WebCore {
 
@@ -46,8 +47,8 @@ class StorageSessionProvider;
 
 class SocketStreamHandleImpl : public SocketStreamHandle {
 public:
-    static Ref<SocketStreamHandleImpl> create(const URL& url, SocketStreamHandleClient& client, PAL::SessionID, Page* page, const String&, SourceApplicationAuditToken&&, const StorageSessionProvider*) {
-        return adoptRef(*new SocketStreamHandleImpl(url, page, client));
+    static Ref<SocketStreamHandleImpl> create(const URL& url, SocketStreamHandleClient& client, PAL::SessionID, Page* page, const String&, SourceApplicationAuditToken&&, const StorageSessionProvider* provider) {
+        return adoptRef(*new SocketStreamHandleImpl(url, page, client, provider));
     }
 
     ~SocketStreamHandleImpl() final;
@@ -59,14 +60,19 @@ public:
 
 protected:
     void platformSend(const uint8_t* data, size_t length, Function<void(bool)>&&) final;
+    Optional<size_t> platformSendInternal(const uint8_t*, size_t);
     void platformSendHandshake(const uint8_t* data, size_t length, const Optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) final;
     void platformClose() final;
-    size_t bufferedAmount() final { return 0; }
+    size_t bufferedAmount() final;
+    bool sendPendingData();
 
 private:
-    SocketStreamHandleImpl(const URL&, Page*, SocketStreamHandleClient&);
+    SocketStreamHandleImpl(const URL&, Page*, SocketStreamHandleClient&, const StorageSessionProvider*);
 
+    RefPtr<const StorageSessionProvider> m_storageSessionProvider;
     JGObject m_ref;
+    StreamBuffer<uint8_t, 1024 * 1024> m_buffer;
+    static const unsigned maxBufferSize = 100 * 1024 * 1024;
 };
 
 }  // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImplJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImplJava.cpp
@@ -106,7 +106,7 @@ Optional<size_t> SocketStreamHandleImpl::platformSendInternal(const uint8_t* dat
     if (WTF::CheckAndClearException(env)) {
         return { };
     }
-    return { res };
+    return { static_cast<size_t>(res) };
 }
 
 void SocketStreamHandleImpl::platformClose()

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImplJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/SocketStreamHandleImplJava.cpp
@@ -43,8 +43,9 @@ static jclass GetSocketStreamHandleClass(JNIEnv* env)
 }
 
 SocketStreamHandleImpl::SocketStreamHandleImpl(const URL& url, Page* page,
-                                       SocketStreamHandleClient& client)
+                                       SocketStreamHandleClient& client, const StorageSessionProvider* provider)
     : SocketStreamHandle(url, client)
+    , m_storageSessionProvider(provider)
 {
     String host = url.host().toString();
     bool ssl = url.protocolIs("wss");
@@ -84,7 +85,7 @@ SocketStreamHandleImpl::~SocketStreamHandleImpl()
     WTF::CheckAndClearException(env);
 }
 
-void SocketStreamHandleImpl::platformSend(const uint8_t* data, size_t len, Function<void(bool)>&& completionHandler)
+Optional<size_t> SocketStreamHandleImpl::platformSendInternal(const uint8_t* data, size_t len)
 {
     JNIEnv* env = WTF::GetJavaEnv();
 
@@ -103,14 +104,9 @@ void SocketStreamHandleImpl::platformSend(const uint8_t* data, size_t len, Funct
 
     jint res = env->CallIntMethod(m_ref, mid, (jbyteArray) byteArray);
     if (WTF::CheckAndClearException(env)) {
-        completionHandler(false);
-    } else {
-        completionHandler(res == (int)len);
+        return { };
     }
-}
-
-void SocketStreamHandleImpl::platformSendHandshake(const uint8_t*, size_t, const Optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&)
-{
+    return { res };
 }
 
 void SocketStreamHandleImpl::platformClose()
@@ -129,8 +125,10 @@ void SocketStreamHandleImpl::platformClose()
 
 void SocketStreamHandleImpl::didOpen()
 {
-    m_state = Open;
-    m_client.didOpenSocketStream(*this);
+    if (m_state == Connecting) {
+        m_state = Open;
+        m_client.didOpenSocketStream(*this);
+    }
 }
 
 void SocketStreamHandleImpl::didReceiveData(const char* data, int length)
@@ -140,13 +138,19 @@ void SocketStreamHandleImpl::didReceiveData(const char* data, int length)
 
 void SocketStreamHandleImpl::didFail(int errorCode, const String& errorDescription)
 {
-    m_client.didFailSocketStream(
-            *this,
-            SocketStreamError(errorCode, m_url.string(), errorDescription));
+    if (m_state == Open) {
+        m_client.didFailSocketStream(
+                *this,
+                SocketStreamError(errorCode, m_url.string(), errorDescription));
+    }
 }
 
 void SocketStreamHandleImpl::didClose()
 {
+    if (m_state == Closed)
+        return;
+    m_state = Closed;
+
     m_client.didCloseSocketStream(*this);
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/PlatformJava.cmake
@@ -4,7 +4,6 @@ configure_file(java/WebCoreSupport/WebPageConfig.h.in ${DERIVED_SOURCES_WEBKITLE
 # Remove unused files
 list(REMOVE_ITEM WebKitLegacy_SOURCES
     WebCoreSupport/WebViewGroup.cpp
-    WebCoreSupport/NetworkStorageSessionMap.cpp
 )
 
 list(APPEND WebKitLegacy_SOURCES

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameNetworkingContextJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameNetworkingContextJava.h
@@ -30,6 +30,7 @@
 #include <WebCore/FrameLoaderClient.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/Page.h>
+#include "NetworkStorageSessionMap.h"
 #include "WebPage.h"
 
 namespace WebCore {
@@ -43,7 +44,12 @@ public:
 
     NetworkStorageSession* storageSession() const override
     {
-        return nullptr;
+        ASSERT(isMainThread());
+
+        if (frame() && frame()->page() && frame()->page()->usesEphemeralSession())
+            return NetworkStorageSessionMap::storageSession(PAL::SessionID::legacyPrivateSessionID());
+
+        return &NetworkStorageSessionMap::defaultStorageSession();
     }
 
 private:


### PR DESCRIPTION
Root cause:
`SocketStreamHandleImpl::platformSendHandshake` is not implemented.

Solution:
SocketStreamHandleImpl.cpp already has boilerplate implementation and used by other WebKit ports as well. Switch to the above mentioned implementation and provide only platform specific functionality like connect, send, receive and close. 

JBS link: https://bugs.openjdk.java.net/browse/JDK-8222912