### PR TITLE
JDK-8227431: [Windows] Fix assertion failure on X86 32-bit when enabling CLOOP based JavaScript interpreter

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
@@ -96,8 +96,7 @@ inline Opcode getOpcodeWide(OpcodeID id)
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide[id];
 #else
-    UNUSED_PARAM(id);
-    RELEASE_ASSERT_NOT_REACHED();
+    return static_cast<Opcode>(id - numOpcodeIDs);
 #endif
 }
 


### PR DESCRIPTION
WebKit's JavaScript interpreter has 2 types of implementation 
1) C_LOOP - Implemented using C constructs (CPU agnostic) 
2) LLInt - Implemented in Low level assembly (CPU specific) 

Interpreter logics are expressed using DSL which is written using Ruby and actual interpreter code is generated(#1 or #2) during the build time. As of today C_LOOP is the supported interpreter mode on 32-bit X86 platform. Since 32-bit X86 is not so commonly used now a days, WebKit's JavaScript interpreter has few unimplemented logics related to C_LOOP. 
  
Implement the function getOpcodeWide which is nothing but a reverse operation of OpcodeID enum value generation. 