### PR TITLE
JDK-8193911: Create README file to document bumping the version number

### DIFF
--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -2,6 +2,8 @@
 
 Here are the instructions for updating the JavaFX release version number
 for a feature release or security (dot-dot) release.
+See [JDK-8226365](https://bugs.openjdk.java.net/browse/JDK-8226365)
+for a recent example.
 
 ## Incrementing the feature version
 

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -1,0 +1,31 @@
+# Updating the JavaFX Release Version
+
+Here are the instructions for updating the JavaFX release version number
+for a feature release or security (dot-dot) release.
+
+## Incrementing the feature version
+
+Here are the steps to increment the JavaFX release version number to a new
+feature version (for example, from 13 to 14).
+
+* In `build.properties`, modify the following properties to increment the
+feature version number from `N` to `N+1`:
+
+```
+    jfx.release.major.version
+    javadoc.title
+    javadoc.header
+```
+
+* In
+`modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java`,
+modify the testMajorVersion method to increment the feature version number
+from `N` to `N+1`.
+
+## Incrementing the security version
+
+Here are the steps to increment the JavaFX release version number to a new
+security version (for example, from 13 to 13.0.1).
+
+* In `build.properties`, modify the `jfx.release.security.version` property
+to increment the security version number from `M` to `M+1`.


### PR DESCRIPTION
JBS issue: [JDK-8193911](https://bugs.openjdk.java.net/browse/JDK-8193911)

This PR adds a new `UPDATING-VERSION.md` file to the repo with instruction for bumping the JavaFX version number, either for a feature release (13 to 14 to 15) or for a security release (13 to 13.0.1 to 13.0.2).
