### PR TITLE
Update .github copy of README.md and CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ OpenJFX is an open source project and we love to receive contributions from our 
 Bug reports
 -----------
 
-If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](http://bugreport.java.com/).
+If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
 
 It is very helpful if you can prepare a reproduction of the bug. In other words, provide a small test case which we can run to confirm your bug. It makes it easier to find the problem and to fix it.
 
@@ -41,7 +41,7 @@ If you are a first time contributor to OpenJFX, welcome! Please do the following
 
 * Sign the Contributor Agreement
 
-    In order for us to evaluate your contribution, you need to sign the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/community/oca-486395.html) (OCA). Ultimately, the goal is to send accepted Pull Requests upstream to the OpenJFX repository hosted on openjdk.java.net. We are not asking you to give up your copyright, but to give us the right to distribute your code without restriction. By doing this you assert that the code you contribute is *yours* to contribute, and not third-party code that you do not own. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the OCA once.
+    In order for us to evaluate your contribution, you need to sign the [Oracle Contributor Agreement](https://www.oracle.com/technetwork/community/oca-486395.html) (OCA). Ultimately, the goal is to send accepted Pull Requests upstream to the OpenJFX repository hosted on openjdk.java.net. We are not asking you to give up your copyright, but to give us the right to distribute your code without restriction. By doing this you assert that the code you contribute is *yours* to contribute, and not third-party code that you do not own. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the OCA once.
 
 * Read the code review policies
 
@@ -63,7 +63,7 @@ Once your changes and tests are ready to submit for review:
 
 3. File a bug in JBS
 
-    If there isn't already a bug filed in [JBS](https://bugs.openjdk.java.net), then please file one at [bugreport.java.com](http://bugreport.java.com/). A JBS bug ID is needed even if you have already filed an issue in the GitHub issue tracker. A GitHub issue can be used as a convenience, but JBS is the official bug database for the OpenJFX Project. Once you submit a pull request, you can add the "github-bug" label on the JBS bug, along with an Issue link to the PR. If you don't have direct JBS access, one of the Project Committers or Authors will do this for you.
+    If there isn't already a bug filed in [JBS](https://bugs.openjdk.java.net), then please file one at [bugreport.java.com](https://bugreport.java.com/). A JBS bug ID is needed even if you have already filed an issue in the GitHub issue tracker. A GitHub issue can be used as a convenience, but JBS is the official bug database for the OpenJFX Project. Once you submit a pull request, you can add the "github-bug" label on the JBS bug, along with an Issue link to the PR. If you don't have direct JBS access, one of the Project Committers or Authors will do this for you.
 
 4. Submit a pull request
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -5,23 +5,23 @@ This repository is a GIT mirror of the official HG [openjfx/jfx-dev/rt](https://
 
 OpenJFX is an open source, next generation client application platform for desktop, mobile and embedded systems based on JavaSE. It is a collaborative effort by many individuals and companies with the goal of producing a modern, efficient, and fully featured toolkit for developing rich client applications. This is the open source project where we develop JavaFX.
 
-OpenJFX is free software, licensed under the [GPL with the class path exception](../LICENSE), just as OpenJDK. Anybody is welcome to contribute to this project, port it to other platforms or devices, or do anything else that a free software license allows you to do! We welcome patches and involvement from individual contributors or companies. See Community for details on how we work and how you can become a contributor.
+OpenJFX is free software, licensed under [GPL v2 with the Classpath exception](../LICENSE), just like the JDK. Anybody is welcome to contribute to this project, port it to other platforms or devices, or do anything else that a free software license allows you to do!
 
-OpenJFX is a project beneath the charter of the OpenJDK. The [OpenJDK Bylaws](http://openjdk.java.net/bylaws) and [License](../LICENSE) govern our work. The OpenJFX project membership can be found on the [OpenJDK Census](http://openjdk.java.net/census#openjfx).
+OpenJFX is a project under the charter of the OpenJDK. The [OpenJDK Bylaws](https://openjdk.java.net/bylaws) and [License](../LICENSE) govern our work. The OpenJFX project membership can be found on the [OpenJDK Census](https://openjdk.java.net/census#openjfx). We welcome patches and involvement from individual contributors or companies. If this is your first time contributing to an OpenJDK project, you will need to review the rules on [becoming a Contributor](https://openjdk.java.net/bylaws#contributor), and sign the [Oracle Contributor Agreement](https://www.oracle.com/technetwork/community/oca-486395.html) (OCA).
 
 ## Issue tracking
 
-If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](http://bugreport.java.com/).
+If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
 
 Please note that while the issue tracker in this Github project can be a convenient place to file an issue (either a bug or an enhancement request), the official bug database for OpenJFX is [JBS](https://bugs.openjdk.java.net).
 
 ## Getting Started
 
-Full instruction can be found at https://wiki.openjdk.java.net/display/OpenJFX/Building+OpenJFX
+For instructions on building JavaFX, see the [Building OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Building+OpenJFX) Wiki page.
+
+For information about downloading and using JavaFX, see the [JavaFX community site](https://openjfx.io/).
 
 
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
-
-


### PR DESCRIPTION
This PR is a simple follow-up fix to PR #526.

Note that there is no corresponding JBS bug ID because this PR is touching GitHub [sandbox-only](https://github.com/javafxports/openjdk-jfx/blob/develop/SANDBOX-FILES.md) files exclusively.

This PR applies the following changes from PR #526 to the `.github/` copies of `README.md` and `CONTRIBUTING.md`.

1. Change all occurrences of `http://` to `https://` in both `README.md` and `CONTRIBUTING.md`
2. Add a pointer to the `openjfx.io` community site to `README.md`
3. Incorporate the minor wording change to `README.md` for first-time contributors.

All of the above changes were reviewed as part of PR #526 so the main purpose of this review is to make sure that no errors crept in while applying the relevant parts of that patch.