### PR TITLE
JDK-8223722: Cleanup .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,25 @@
-# FIXME: Eventually we should include the needed patterns from .hgingore
-# The goal is that a full build & test, followed by "git status" would show
-# no untracked files
-
-*.orig
-*.bak
-*.rej
-*.swp
-build/
+# Ignore the following directories and files
 .gradle/
-**/nbproject/private/
-dist/
-webrev/
-webrev.zip
-gradle.properties
 apps/samples/Ensemble8/lib/
+build/
+dist/
+gradle.properties
+**/nbproject/private/
 
+# Ignore webrevs
+webrev.zip
+webrev/
+
+# Ignore IntelliJ files
 .idea/tasks.xml
 .idea/workspace.xml
 .idea/inspectionProfiles/*
 .idea/copyright/profiles_settings.xml
 .idea/codeStyles/*
 .idea/checkstyle-idea.xml
+
+# Ignore the following file suffixes
+*.orig
+*.bak
+*.rej
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,33 @@
 # Ignore the following directories and files
 .gradle/
-apps/samples/Ensemble8/lib/
+.hg/
+Debug/
+Release/
+bin/
 build/
 dist/
 gradle.properties
+testbin/
+**/Ensemble8/lib/
+**/Ensemble8/src/generated/resources/ensemble/search/index/write.lock
 **/nbproject/private/
 
 # Ignore webrevs
-webrev.zip
-webrev/
+/webrev/
+/webrev.zip
 
 # Ignore IntelliJ files
 .idea/tasks.xml
 .idea/workspace.xml
-.idea/inspectionProfiles/*
+.idea/inspectionProfiles/**
 .idea/copyright/profiles_settings.xml
-.idea/codeStyles/*
+.idea/codeStyles/**
 .idea/checkstyle-idea.xml
 
 # Ignore the following file suffixes
+*.vcxproj.user
 *.orig
 *.bak
 *.rej
 *.swp
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ testbin/
 /webrev/
 /webrev.zip
 
+# Ignore Eclipse files
+org.eclipse.buildship*
+
 # Ignore IntelliJ files
 .idea/tasks.xml
 .idea/workspace.xml


### PR DESCRIPTION
JBS issue: [JDK-8223722](https://bugs.openjdk.java.net/browse/JDK-8223722)

Simple fix to cleanup the `.gitignore` file and add a few useful missing patterns.

As a help to reviewers, I pushed two commits:

1. Fix/add comments and reorganize the existing patterns without adding or removing any patterns
2. Add new patterns / modify existing patterns

If you want to see what was actually changed (as opposed to reordered), you can just look at the second commit.