### PR TITLE
JDK-8228766: [Mac] fix deadlock in platform.startup(Runnable r)

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -51,7 +51,9 @@ public final class Platform {
      *
      * <p>
      * This method may or may not return to the caller before the run method
-     * of the specified Runnable has been called. In any case, once this method
+     * of the specified Runnable has been called. In any case, this 
+     * method is not blocked on the specified Runnable being executed.
+     * Once this method
      * returns, you may call {@link #runLater(Runnable)} with additional Runnables.
      * Those Runnables will be called, also on the JavaFX Application Thread,
      * after the Runnable passed into this method has been called.

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -51,7 +51,7 @@ public final class Platform {
      *
      * <p>
      * This method may or may not return to the caller before the run method
-     * of the specified Runnable has been called. In any case, this 
+     * of the specified Runnable has been called. In any case, this
      * method is not blocked on the specified Runnable being executed.
      * Once this method
      * returns, you may call {@link #runLater(Runnable)} with additional Runnables.

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -168,6 +168,9 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     {
+        // unblock main thread. Glass is started at this point.
+        self->started = YES;
+
         if (self->jLaunchable != NULL)
         {
             jclass runnableClass = [GlassHelper ClassForName:"java.lang.Runnable" withEnv:jEnv];
@@ -226,8 +229,6 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         }
 
         (*env)->CallVoidMethod(env, self->jApplication, [GlassHelper ApplicationNotifyWillFinishLaunchingMethod]);
-
-        self->started = YES;
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);

--- a/tests/system/src/test/java/test/com/sun/javafx/application/ConcurrentStartupTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/ConcurrentStartupTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.application;
+
+import javafx.application.Platform;
+import org.junit.AfterClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrentStartupTest {
+    CountDownLatch startupLatch;
+    CountDownLatch mainLatch;
+    volatile Throwable error = null;
+
+    @Test (timeout=15000)
+    public void testStartupReturnBeforeRunnableComplete() throws Exception {
+        startupLatch = new CountDownLatch(2);
+        mainLatch = new CountDownLatch(1);
+        Platform.startup(() -> {
+            try {
+                if (!mainLatch.await(10, TimeUnit.SECONDS)) {
+                    error = new AssertionError("Timeout waiting for main latch");
+                }
+                try {
+                    assertEquals("Runnable executed out of order", 2, startupLatch.getCount());
+                } catch (Throwable err) {
+                    error = err;
+                }
+            } catch (InterruptedException ex) {
+                error = ex;
+            }
+            startupLatch.countDown();
+        });
+        Platform.runLater(() -> {
+            try {
+                assertEquals("Runnable executed out of order", 1, startupLatch.getCount());
+            } catch (Throwable err) {
+                error = err;
+            }
+            startupLatch.countDown();
+        });
+        mainLatch.countDown();
+        assertTrue(startupLatch.await(10, TimeUnit.SECONDS));
+        if (error != null) {
+            if (error instanceof Error) {
+                throw (Error) error;
+            } else {
+                throw (Exception) error;
+            }
+        }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.exit();
+    }
+}

--- a/tests/system/src/test/java/test/com/sun/javafx/application/StaticStartupTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/StaticStartupTest.java
@@ -42,6 +42,15 @@ public class StaticStartupTest {
 
     @Test (timeout=15000)
     public void testStartupFromClinit() throws Exception {
+        Thread thr = new Thread(() -> {
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException ex) {}
+            System.err.println("Test timeout exceeded -- calling System.exit");
+            System.exit(1);
+        });
+        thr.setDaemon(true);
+        thr.start();
         StaticClass.doSomething();
     }
 

--- a/tests/system/src/test/java/test/com/sun/javafx/application/StaticStartupTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/StaticStartupTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.application;
+
+import javafx.application.Platform;
+import junit.framework.AssertionFailedError;
+import org.junit.AfterClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class StaticStartupTest {
+
+    @Test (timeout=15000)
+    public void testStartupFromClinit() throws Exception {
+        StaticClass.doSomething();
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.exit();
+    }
+}
+
+class StaticClass {
+
+    static CountDownLatch staticLatch = new CountDownLatch(1);
+    static Throwable err = null;
+
+    static {
+        Platform.startup(() -> {
+            staticLatch.countDown();
+        });
+    }
+
+    static void doSomething() {
+        Platform.runLater(() -> {
+            try {
+                assertEquals(staticLatch.getCount(), 0);
+            } catch (Throwable th) {
+                throw new AssertionFailedError ("Static latch couldn't be read");
+            }
+        });
+    }
+}


### PR DESCRIPTION
allow main thread to continue before calling the runnable that is provided with Platform.startup().
This fixes #542 or JDK-8228766