### PR TITLE
JDK-8179097: Fix NPE on removing mnemonics of disposed popup

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -60,6 +60,7 @@ import javafx.scene.text.TextBoundsType;
 import javafx.scene.text.HitInfo;
 
 import java.text.Bidi;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -693,6 +694,10 @@ public class Utils {
     }
 
     public static void addMnemonics(ContextMenu popup, Scene scene, boolean initialState) {
+        addMnemonics(popup, scene, initialState, null);
+    }
+
+    public static void addMnemonics(ContextMenu popup, Scene scene, boolean initialState, List<Mnemonic> into) {
 
         if (!com.sun.javafx.PlatformUtil.isMac()) {
 
@@ -713,6 +718,9 @@ public class Utils {
                         Mnemonic myMnemonic = new Mnemonic(cmContent.getLabelAt(i), mnemonicKeyCombo);
                         scene.addMnemonic(myMnemonic);
                         NodeHelper.setShowMnemonics(cmContent.getLabelAt(i), initialState);
+                        if (into != null) {
+                            into.add(myMnemonic);
+                        }
                     }
                 }
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -193,10 +193,9 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
                 // consumed to prevent them being used elsewhere).
                 // See JBS-8090026 for more detail.
                 Scene scene = getSkinnable().getScene();
-                Platform.runLater(() -> {
-                    mnemonics.forEach(scene::removeMnemonic);
-                    mnemonics.clear();
-                });
+                List<Mnemonic> mnemonicsToRemove = new ArrayList<>(mnemonics);
+                mnemonics.clear();
+                Platform.runLater(() -> mnemonicsToRemove.forEach(scene::removeMnemonic));
             }
         });
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -34,15 +34,20 @@ import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Skin;
 import javafx.scene.control.SkinBase;
+import javafx.scene.input.Mnemonic;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import com.sun.javafx.scene.control.behavior.MenuButtonBehaviorBase;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base class for MenuButtonSkin and SplitMenuButtonSkin. It consists of the
@@ -168,6 +173,7 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
             label.setMnemonicParsing(getSkinnable().isMnemonicParsing());
             getSkinnable().requestLayout();
         });
+        List<Mnemonic> mnemonics = new ArrayList<>();
         registerChangeListener(popup.showingProperty(), e -> {
             if (!popup.isShowing() && getSkinnable().isShowing()) {
                 // Popup was dismissed. Maybe user clicked outside or typed ESCAPE.
@@ -176,7 +182,8 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
             }
 
             if (popup.isShowing()) {
-                Utils.addMnemonics(popup, getSkinnable().getScene(), NodeHelper.isShowMnemonics(getSkinnable()));
+                boolean showMnemonics = NodeHelper.isShowMnemonics(getSkinnable());
+                Utils.addMnemonics(popup, getSkinnable().getScene(), showMnemonics, mnemonics);
             } else {
                 // we wrap this in a runLater so that mnemonics are not removed
                 // before all key events are fired (because KEY_PRESSED might have
@@ -185,7 +192,11 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
                 // through the mnemonics code (especially in case they should be
                 // consumed to prevent them being used elsewhere).
                 // See JBS-8090026 for more detail.
-                Platform.runLater(() -> Utils.removeMnemonics(popup, getSkinnable().getScene()));
+                Scene scene = getSkinnable().getScene();
+                Platform.runLater(() -> {
+                    mnemonics.forEach(scene::removeMnemonic);
+                    mnemonics.clear();
+                });
             }
         });
     }

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.javafx.scene.control;
 
 import javafx.application.Application;

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -1,0 +1,84 @@
+package test.javafx.scene.control;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class MenuButtonSkinBaseNPETest {
+    static CountDownLatch startupLatch;
+    static Menu menu;
+    static MenuBar menuBar;
+
+    public static void main(String[] args) throws Exception {
+        initFX();
+        try {
+            var test = new MenuButtonSkinBaseNPETest();
+            test.testMenuButtonNPE();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            tearDown();
+        }
+    }
+
+    @Test
+    public void testMenuButtonNPE() throws Exception {
+        PrintStream defaultErrorStream = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(out,true));
+        Thread.sleep(1000);
+        Platform.runLater(()-> {
+            menu.hide();
+            menuBar.getMenus().clear();
+        });
+        Thread.sleep(100);
+        System.setErr(defaultErrorStream);
+        Assert.assertEquals("No error should be thrown","", out.toString());
+    }
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            menu = new Menu("Menu", null, new MenuItem("Press '_a'"));
+            menuBar = new MenuBar(menu);
+            Scene scene = new Scene(menuBar);
+            primaryStage.addEventHandler(WindowEvent.WINDOW_SHOWN, event -> startupLatch.countDown());
+            primaryStage.setScene(scene);
+            primaryStage.show();
+            menu.show();
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                Assert.fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            Assert.fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Platform.exit();
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -65,9 +65,9 @@ public class MenuButtonSkinBaseNPETest {
     public void testMenuButtonNPE() throws Exception {
         PrintStream defaultErrorStream = System.err;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(out,true));
+        System.setErr(new PrintStream(out, true));
         Thread.sleep(1000);
-        Util.runAndWait(()-> {
+        Util.runAndWait(() -> {
             menu.hide();
             menuBar.getMenus().clear();
         });

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -37,6 +37,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import test.util.Util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -66,13 +67,13 @@ public class MenuButtonSkinBaseNPETest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setErr(new PrintStream(out,true));
         Thread.sleep(1000);
-        Platform.runLater(()-> {
+        Util.runAndWait(()-> {
             menu.hide();
             menuBar.getMenus().clear();
         });
         Thread.sleep(100);
         System.setErr(defaultErrorStream);
-        Assert.assertEquals("No error should be thrown","", out.toString());
+        Assert.assertEquals("No error should be thrown", "", out.toString());
     }
 
     public static class TestApp extends Application {
@@ -90,16 +91,11 @@ public class MenuButtonSkinBaseNPETest {
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
         new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+        Assert.assertTrue("Timeout waiting for FX runtime to start",
+                startupLatch.await(15, TimeUnit.SECONDS));
     }
 
     @AfterClass


### PR DESCRIPTION
Hi! This is a follow-up PR for issue https://github.com/javafxports/openjdk-jfx/issues/465
I signed OCA (received welcome letter from @kevinrushforth on 26th of July).

I managed to create a stable repro case, see `MenuButtonSkinBaseNPETest.java`.
Most important lines in repro are 45-46:
```java
            menu.hide();
            menuBar.getMenus().clear();
```
When you hide menu which is in a menu bar, it scheduled mnemonics removal in runLater:
```java
Platform.runLater(() -> Utils.removeMnemonics(popup, getSkinnable().getScene()));
```
But when you clear said menu bar, it disposes all menus, which leaded to all sorts of exceptions: `getSkinnable` in MenuButtonSkinBase becomes null, but also popup's skin becomes null (and we access it later in `Utils::removeMnemonics`).

The fix is to save added mnemonics to a list so we don't depend on external state which will be mutated on disposing, and use that list when we want to remove them.

I run all tests with `bash ./gradlew -PFULL_TEST=true -PUSE_ROBOT=true -x web:test all test`.
Before fix:
```
649 tests completed, 20 failed, 119 skipped
```
One of the failed tests is what I added:
```
test.javafx.scene.control.MenuButtonSkinBaseNPETest > testMenuButtonNPE FAILED
    org.junit.ComparisonFailure: No error should be thrown expected:<[]> but was:<[Exception in thread "JavaFX Application Thread" java.lang.NullPointerException
        at javafx.controls/javafx.scene.control.skin.MenuButtonSkinBase.lambda$new$7(MenuButtonSkinBase.java:195)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:428)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:427)
        at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
        at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
        at java.base/java.lang.Thread.run(Thread.java:834)
    ]>
        at org.junit.Assert.assertEquals(Assert.java:123)
        at test.javafx.scene.control.MenuButtonSkinBaseNPETest.testMenuButtonNPE(MenuButtonSkinBaseNPETest.java:50)
Exception in thread "JavaFX Application Thread" 
```
After fix:
```
649 tests completed, 17 failed, 119 skipped
```
My repro case is not present in the list of failed tests.