### PR TITLE
JDK-8227431: [Windows] Fix assertion failure on X86 32-bit when enabling CLOOP based JavaScript interpreter

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
@@ -96,8 +96,7 @@ inline Opcode getOpcodeWide(OpcodeID id)
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide[id];
 #else
-    UNUSED_PARAM(id);
-    RELEASE_ASSERT_NOT_REACHED();
+    return static_cast<Opcode>(id - numOpcodeIDs);
 #endif
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/CommonVM.cpp
@@ -73,6 +73,11 @@ JSC::VM& commonVMSlow()
 Frame* lexicalFrameFromCommonVM()
 {
     if (auto* topCallFrame = commonVM().topCallFrame) {
+#if PLATFORM(JAVA) && ENABLE(C_LOOP)
+        if (!topCallFrame->codeBlock()) {
+            return nullptr;
+        }
+#endif
         if (auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(topCallFrame->lexicalGlobalObject())) {
             if (auto* window = JSC::jsDynamicCast<JSDOMWindow*>(commonVM(), globalObject)) {
                 if (auto* frame = window->wrapped().frame())


### PR DESCRIPTION
JBS bug: https://bugs.openjdk.java.net/browse/JDK-8227431

Follow on to PR #525 

Includes PR 525 + nullptr check for C_LOOP (i.e only for x86 build).