### PR TITLE
JDK-8220396: Bindings class gives a lot of unneeded 'select-binding' log messages

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/SelectBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/SelectBinding.java
@@ -486,13 +486,15 @@ public class SelectBinding {
                 } catch (RuntimeException ex) {
                     final PlatformLogger logger = Logging.getLogger();
                     if (logger.isLoggable(Level.WARNING)) {
-                        Logging.getLogger().warning("Exception while evaluating select-binding " + stepsToString());
-                        if (ex instanceof  IllegalStateException) {
+                        String msg = "Exception while evaluating select-binding " + stepsToString();
+                        if (ex instanceof IllegalStateException) {
+                            logger.warning(msg);
                             logger.warning("Property '" + propertyNames[i] + "' does not exist in " + obj.getClass(), ex);
                         } else if (ex instanceof NullPointerException) {
+                            logger.fine(msg);
                             logger.fine("Property '" + propertyNames[i] + "' in " + properties[i] + " is null", ex);
                         } else {
-                            Logging.getLogger().warning("", ex);
+                            logger.warning(msg, ex);
                         }
                     }
                     // return default


### PR DESCRIPTION
Fix for bug JDK-8220396
See https://bugs.openjdk.java.net/browse/JDK-8220396 and
https://github.com/javafxports/openjdk-jfx/issues/383

Attached is a new standalone test program which verifies that the fix works and that other errors are still reported as before. I could not test the else-part of the exception handler because I did not find any condition where this is executed.

[NewBindingsEval.java.zip](https://github.com/javafxports/openjdk-jfx/files/3464919/NewBindingsEval.java.zip)
