### PR TITLE
JDK-8229328: [windows] PlatformFileHandle type should be JGObject rather than void*

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/FileSystem.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/FileSystem.h
@@ -70,7 +70,7 @@ namespace FileSystemImpl {
 #if USE(GLIB) && !OS(WINDOWS)
 typedef GFileIOStream* PlatformFileHandle;
 const PlatformFileHandle invalidPlatformFileHandle = 0;
-#elif OS(WINDOWS)
+#elif OS(WINDOWS) && !PLATFORM(JAVA)
 typedef HANDLE PlatformFileHandle;
 // FIXME: -1 is INVALID_HANDLE_VALUE, defined in <winbase.h>. Chromium tries to
 // avoid using Windows headers in headers. We'd rather move this into the .cpp.


### PR DESCRIPTION
On Windows platform PlatformFileHandle type is considered as HANDLE (i.e void *) which is specific to Windows flavor of webkit port. 
For OpenJFX, type of PlatformFileHandle should be JGObject. 

Due to this failure, randomly (at times) the type of FileHandle returned from native webkit will be other than java.io.RandomAccessFile