### PR TITLE
Fix and test for JDK-8229890

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/image/PixelBuffer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/image/PixelBuffer.java
@@ -189,15 +189,17 @@ public class PixelBuffer<T extends Buffer> {
         Toolkit.getToolkit().checkFxUserThread();
         Objects.requireNonNull(callback, "callback must not be null.");
         Rectangle2D rect2D = callback.call(this);
-        Rectangle rect = null;
         if (rect2D != null) {
-            int x1 = (int) Math.floor(rect2D.getMinX());
-            int y1 = (int) Math.floor(rect2D.getMinY());
-            int x2 = (int) Math.ceil(rect2D.getMaxX());
-            int y2 = (int) Math.ceil(rect2D.getMaxY());
-            rect = new Rectangle(x1, y1, x2 - x1, y2 - y1);
+            if (rect2D.getWidth() > 0 && rect2D.getHeight() > 0) {
+                int x1 = (int) Math.floor(rect2D.getMinX());
+                int y1 = (int) Math.floor(rect2D.getMinY());
+                int x2 = (int) Math.ceil(rect2D.getMaxX());
+                int y2 = (int) Math.ceil(rect2D.getMaxY());
+                bufferDirty(new Rectangle(x1, y1, x2 - x1, y2 - y1));
+            }
+        } else {
+            bufferDirty(null);
         }
-        bufferDirty(rect);
     }
 
     private void bufferDirty(Rectangle rect) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/image/PixelBufferTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/image/PixelBufferTest.java
@@ -134,6 +134,17 @@ public final class PixelBufferTest {
     }
 
     @Test
+    public void testUpdatePixelBufferEmptyBufferUpdate() {
+        // This test verifies that an empty dirty region does not cause any exception
+        PixelBuffer<ByteBuffer> pixelBuffer = new PixelBuffer<>(WIDTH, HEIGHT, BYTE_BUFFER, BYTE_BGRA_PRE_PF);
+        Callback<PixelBuffer<ByteBuffer>, Rectangle2D> callback = pixBuf -> {
+            // Assuming this Callback modifies the buffer.
+            return Rectangle2D.EMPTY;
+        };
+        pixelBuffer.updateBuffer(callback);
+    }
+
+    @Test
     public void testUpdatePixelBufferCallbackNull() {
         try {
             PixelBuffer<ByteBuffer> pixelBuffer = new PixelBuffer<>(WIDTH, HEIGHT, BYTE_BUFFER, BYTE_BGRA_PRE_PF);


### PR DESCRIPTION
Modified PixelBuffer update method so that an empty rectangle returned by the callback is handled as a no-op and does not throw an exception.
Added a test to ensure that no exception is thrown anymore.
See:
https://bugs.openjdk.java.net/browse/JDK-8229890
https://github.com/javafxports/openjdk-jfx/issues/567