### PR TITLE
JDK-8207774: TextField must not forward ENTER if action consumed

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -178,7 +178,8 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     @Override protected void fire(KeyEvent event) {
         TextField textField = getNode();
         EventHandler<ActionEvent> onAction = textField.getOnAction();
-        ActionEvent actionEvent = new ActionEvent(textField, null);
+        // fix JDK-8207774: use textField as target to prevent immediate copy in dispatch
+        ActionEvent actionEvent = new ActionEvent(textField, textField);
 
         textField.commitValue();
         textField.fireEvent(actionEvent);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -178,7 +178,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     @Override protected void fire(KeyEvent event) {
         TextField textField = getNode();
         EventHandler<ActionEvent> onAction = textField.getOnAction();
-        // fix JDK-8207774: use textField as target to prevent immediate copy in dispatch
+        // use textField as target to prevent immediate copy in dispatch
         ActionEvent actionEvent = new ActionEvent(textField, textField);
 
         textField.commitValue();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -306,14 +306,14 @@ public class TextFieldTest {
     /**
      * test for JDK-8207774: ENTER must not be forwared if actionHandler
      * consumed the action.
-     * 
+     *
      * Here we test that an accelerator is not triggered.
      */
     @Test
     public void testEnterWithConsumingActionHandlerAccelerator() {
         initStage();
         root.getChildren().add(txtField);
-        txtField.addEventHandler(ActionEvent.ACTION, e -> 
+        txtField.addEventHandler(ActionEvent.ACTION, e ->
         e.consume()
                 );
         scene.getAccelerators().put(new KeyCodeCombination(ENTER), () ->
@@ -322,18 +322,18 @@ public class TextFieldTest {
         KeyEventFirer keyboard = new KeyEventFirer(txtField);
         keyboard.doKeyPress(ENTER);
     }
-    
+
     /**
      * test for JDK-8207774: ENTER must not be forwared if actionHandler
      * consumed the action.
-     * 
+     *
      * Here we test that handlers on parent are not notified.
      */
     @Test
     public void testEnterWithConsumingActionHandlerParentHandler() {
         initStage();
         root.getChildren().add(txtField);
-        txtField.addEventHandler(ActionEvent.ACTION, e -> 
+        txtField.addEventHandler(ActionEvent.ACTION, e ->
             e.consume()
         );
         root.addEventHandler(KeyEvent.KEY_PRESSED, e ->
@@ -342,7 +342,7 @@ public class TextFieldTest {
         KeyEventFirer keyboard = new KeyEventFirer(txtField);
         keyboard.doKeyPress(ENTER);
     }
-    
+
     /**
      * sanity: pressing enter actually triggers a consuming actionHandler.
      */
@@ -361,7 +361,7 @@ public class TextFieldTest {
         assertEquals("actionHandler must be notified", 1, actions.size());
         assertTrue("action must be consumed ", actions.get(0).isConsumed());
     }
-    
+
     /**
      * Helper method to init the stage only if really needed.
      */

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -298,7 +298,6 @@ public class TextFieldTest {
         assertEquals("x", dummyTxtField.getText());
     }
 
-    private Toolkit tk;
     private Scene scene;
     private Stage stage;
     private StackPane root;
@@ -313,9 +312,7 @@ public class TextFieldTest {
     public void testEnterWithConsumingActionHandlerAccelerator() {
         initStage();
         root.getChildren().add(txtField);
-        txtField.addEventHandler(ActionEvent.ACTION, e ->
-        e.consume()
-                );
+        txtField.addEventHandler(ActionEvent.ACTION, e -> e.consume());
         scene.getAccelerators().put(new KeyCodeCombination(ENTER), () ->
             fail("accelerator must not be notified"));
         stage.show();
@@ -333,11 +330,9 @@ public class TextFieldTest {
     public void testEnterWithConsumingActionHandlerParentHandler() {
         initStage();
         root.getChildren().add(txtField);
-        txtField.addEventHandler(ActionEvent.ACTION, e ->
-            e.consume()
-        );
+        txtField.addEventHandler(ActionEvent.ACTION, e -> e.consume());
         root.addEventHandler(KeyEvent.KEY_PRESSED, e ->
-                fail("parent handler must not be notified but received: " + e ));
+            fail("parent handler must not be notified but received: " + e ));
         stage.show();
         KeyEventFirer keyboard = new KeyEventFirer(txtField);
         keyboard.doKeyPress(ENTER);
@@ -366,7 +361,8 @@ public class TextFieldTest {
      * Helper method to init the stage only if really needed.
      */
     private void initStage() {
-        tk = (StubToolkit)Toolkit.getToolkit();//This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        //This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        Toolkit tk = (StubToolkit)Toolkit.getToolkit();
         root = new StackPane();
         scene = new Scene(root);
         stage = new Stage();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -25,7 +25,20 @@
 
 package test.javafx.scene.control;
 
-import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.sun.javafx.tk.Toolkit;
+
+import static javafx.scene.input.KeyCode.*;
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
+
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -37,12 +50,13 @@ import javafx.event.EventHandler;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControlShim;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
-import static org.junit.Assert.*;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import test.com.sun.javafx.pgstub.StubToolkit;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 public class TextFieldTest {
     private TextField txtField;//Empty string
@@ -284,6 +298,85 @@ public class TextFieldTest {
         assertEquals("x", dummyTxtField.getText());
     }
 
+    private Toolkit tk;
+    private Scene scene;
+    private Stage stage;
+    private StackPane root;
 
+    /**
+     * test for JDK-8207774: ENTER must not be forwared if actionHandler
+     * consumed the action.
+     * 
+     * Here we test that an accelerator is not triggered.
+     */
+    @Test
+    public void testEnterWithConsumingActionHandlerAccelerator() {
+        initStage();
+        root.getChildren().add(txtField);
+        txtField.addEventHandler(ActionEvent.ACTION, e -> 
+        e.consume()
+                );
+        scene.getAccelerators().put(new KeyCodeCombination(ENTER), () ->
+            fail("accelerator must not be notified"));
+        stage.show();
+        KeyEventFirer keyboard = new KeyEventFirer(txtField);
+        keyboard.doKeyPress(ENTER);
+    }
+    
+    /**
+     * test for JDK-8207774: ENTER must not be forwared if actionHandler
+     * consumed the action.
+     * 
+     * Here we test that handlers on parent are not notified.
+     */
+    @Test
+    public void testEnterWithConsumingActionHandlerParentHandler() {
+        initStage();
+        root.getChildren().add(txtField);
+        txtField.addEventHandler(ActionEvent.ACTION, e -> 
+            e.consume()
+        );
+        root.addEventHandler(KeyEvent.KEY_PRESSED, e ->
+                fail("parent handler must not be notified but received: " + e ));
+        stage.show();
+        KeyEventFirer keyboard = new KeyEventFirer(txtField);
+        keyboard.doKeyPress(ENTER);
+    }
+    
+    /**
+     * sanity: pressing enter actually triggers a consuming actionHandler.
+     */
+    @Test
+    public void testEnterWithConsumingActionHandler() {
+        initStage();
+        root.getChildren().add(txtField);
+        List<ActionEvent> actions = new ArrayList<>();
+        txtField.addEventHandler(ActionEvent.ACTION, e -> {
+            e.consume();
+            actions.add(e);
+        });
+        stage.show();
+        KeyEventFirer keyboard = new KeyEventFirer(txtField);
+        keyboard.doKeyPress(ENTER);
+        assertEquals("actionHandler must be notified", 1, actions.size());
+        assertTrue("action must be consumed ", actions.get(0).isConsumed());
+    }
+    
+    /**
+     * Helper method to init the stage only if really needed.
+     */
+    private void initStage() {
+        tk = (StubToolkit)Toolkit.getToolkit();//This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        root = new StackPane();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+    }
 
+    @After
+    public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
+    }
 }


### PR DESCRIPTION
This is a (limited, see below) fix for https://bugs.openjdk.java.net/browse/JDK-8207774. 

The issue is that the keyPressed of ENTER on the TextField is forwarded up the parent chain, even if an actionHandler consumed the fired action. The technical reason is that the action may be copied during dispatch, such that the action that's consumed is a different instance than the instance that's sent. If that happens, the consumed state of the sent action will always be false.

This change sends an actionEvent with the textField as eventTarget - doing so prevents the _immediate_ copy of the action. 

To test the change, the sample code in the bug report was converted to two fixtures in TextFieldTest - they failed before the change and pass after.

Limitation: the actionEvent may be copied elsewhere during the dispatch, see related issues in the report (f.i. when having an eventFilter somewhere up the parent chain). If so, the fix doesn't help. 

