### PR TITLE
JDK-8230361: [web] Cookies are not enabled in WebKit v608.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
@@ -38,6 +38,7 @@
 #include "EditorClientJava.h"
 #include "FrameLoaderClientJava.h"
 #include "InspectorClientJava.h"
+#include "PageStorageSessionProvider.h"
 #include "PlatformStrategiesJava.h"
 #include "ProgressTrackerClientJava.h"
 #include "VisitedLinkStoreJava.h"
@@ -53,10 +54,8 @@
 #include <JavaScriptCore/JSContextRefPrivate.h>
 #include <JavaScriptCore/JSStringRef.h>
 #include <JavaScriptCore/Options.h>
-#include <PageStorageSessionProvider.h>
 #include <WebCore/BackForwardController.h>
 #include <WebCore/BridgeUtils.h>
-#include <WebCore/CacheStorageProvider.h>
 #include <WebCore/CharacterData.h>
 #include <WebCore/Chrome.h>
 #include <WebCore/ContextMenu.h>
@@ -82,7 +81,6 @@
 #include <WebCore/GraphicsLayerTextureMapper.h>
 #include <WebCore/InspectorController.h>
 #include <WebCore/KeyboardEvent.h>
-#include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/NodeTraversal.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageConfiguration.h>
@@ -100,7 +98,6 @@
 #include <WebCore/ScriptController.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/Settings.h>
-#include <WebCore/SocketProvider.h>
 #include <WebCore/StorageNamespaceProvider.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/TextureMapperJava.h>

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -227,6 +227,16 @@ public class MiscellaneousTest extends TestBase {
         }
     }
 
+    @Test public void testCookieEnabled() {
+        final WebEngine webEngine = createWebEngine();
+        submit(() -> {
+            final JSObject window = (JSObject) webEngine.executeScript("window");
+            assertNotNull(window);
+            webEngine.executeScript("var cookieEnabled = navigator.cookieEnabled");
+            assertTrue((Boolean)window.getMember("cookieEnabled"));
+        });
+    }
+
     // This test case will be removed once we implement Websql feature.
     @Test public void testWebSQLUndefined() {
         final WebEngine webEngine = createWebEngine();


### PR DESCRIPTION
Cookiejar Object didn't had valid StorageSessionProvider object, This was due to fix in webkit https://trac.webkit.org/changeset/240014/webkit.

Solution : Create CookieJar with PageStorageSessionProvider (with Page Ref) and add to Page Configuration. 

Test : Load https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_nav_cookieenabled and check for "Cookies enabled: true" 