### PR TITLE
8231126: libxslt.md has incorrect version string

### DIFF
--- a/modules/javafx.web/src/main/legal/libxslt.md
+++ b/modules/javafx.web/src/main/legal/libxslt.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxslt v1.1.32
+## xmlsoft.org: libxslt v1.1.33
 
 ### libxslt License
 ```


### PR DESCRIPTION
JBS bug: [JDK-8231126](https://bugs.openjdk.java.net/browse/JDK-8231126)

Simple fix to re-apply the correct version number string in the `/legal/libxslt.md` file, which was inadvertently reverted by the fix for [JDK-8222746](https://bugs.openjdk.java.net/browse/JDK-8222746).
