### PR TITLE
WIP: JDK-8231372: Correctly terminate secondary event loop in JFXPanel.setScene()

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -299,12 +299,11 @@ public class JFXPanel extends JComponent {
                     (PrivilegedAction<EventQueue>) java.awt.Toolkit
                             .getDefaultToolkit()::getSystemEventQueue);
             SecondaryLoop secondaryLoop = eventQueue.createSecondaryLoop();
-            if (secondaryLoop.enter()) {
-                Platform.runLater(() -> {
-                    setSceneImpl(newScene);
-                });
+            Platform.runLater(() -> {
+                setSceneImpl(newScene);
                 secondaryLoop.exit();
-            }
+            });
+            secondaryLoop.enter();
         }
     }
 


### PR DESCRIPTION
Secondary event loop introduced as a means of synchronization with the JavaFX
Application thread in [1] never terminates as the SecondaryLoop.exit() call is
not reached because the thread is blocked in the SecondaryLoop.enter() call.
This patch fixes the problem by submitting the UI work (including the call
to the SecondaryLoop.exit() method) before entering the secondary loop.

[1] https://github.com/javafxports/openjdk-jfx/commit/b66d0816dbef4e1f55153d268770f3dfff3d910f