### PR TITLE
8231310: Add .jcheck/conf to jfx git repo

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -43,3 +43,6 @@ minimum=1
 
 [checks "merge"]
 message=Merge
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -29,7 +29,7 @@ jbs=jdk
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))
 
 [checks]
-error=blacklist,author,reviewers,merge,hg-tag,message,issues,whitespace,executable
+error=blacklist,author,reviewers,merge,message,issues,whitespace,executable
 
 [census]
 version=0
@@ -40,3 +40,6 @@ files=.*\.java$|.*\.c$|.*\.h$|.*\.cpp$|.*\.hpp$
 
 [checks "reviewers"]
 minimum=1
+
+[checks "merge"]
+message=Merge

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,0 +1,42 @@
+;
+; Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+[general]
+project=openjfx
+jbs=jdk
+
+[repository]
+tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))
+
+[checks]
+error=blacklist,author,reviewers,merge,hg-tag,message,issues,whitespace,executable
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.java$|.*\.c$|.*\.h$|.*\.cpp$|.*\.hpp$
+
+[checks "reviewers"]
+minimum=1


### PR DESCRIPTION
NOTE: DO NOT MERGE THIS PR

JBS issue: [JDK-8231310](https://bugs.openjdk.java.net/browse/JDK-8231310)

This adds a `.jcheck/conf` file to the `jfx` repo. As indicated in the JBS issue, I will wait to actually integrate this change until the day before the switch to GIT, as the last commit pushed to the HG repo right before that repo is made read-only.

The `.jcheck/conf file` enables the same checks as currently configured for `hg jcheck`. The following rules are enforced:

1. White-space checking in the set of files recognized by `hg jcheck`
2. No executable files in the repo
2. Commit message must start with an issue ID --includes changes for [SKARA-80](https://bugs.openjdk.java.net/browse/SKARA-80)
3. Each commit has a minimum of 1 review from someone with a `Reviewer` role in the project
